### PR TITLE
fix: Rename amount -> value in acquisition link

### DIFF
--- a/pyopds2_openlibrary/__init__.py
+++ b/pyopds2_openlibrary/__init__.py
@@ -141,7 +141,7 @@ def ol_acquisition_to_opds_acquisition_link(acq: OpenLibraryDataRecord.EditionPr
         amount, currency = acq.price.split(" ")
         link.properties = {
             "price": {
-                "amount": float(amount),
+                "value": float(amount),
                 "currency": currency,
             }
         }


### PR DESCRIPTION
This makes the field name spec compliant:
https://drafts.opds.io/opds-2.0#53-acquisition-links