### PR TITLE
Expand availability; support unavailable

### DIFF
--- a/pyopds2_openlibrary/__init__.py
+++ b/pyopds2_openlibrary/__init__.py
@@ -152,9 +152,17 @@ def ol_acquisition_to_opds_acquisition_link(
         href=acq.url,
         rel=f'http://opds-spec.org/acquisition/{acq.access}',
         type=map_ol_format_to_mime(acq.format) if acq.format else None,
+        properties={}
     )
 
-    link.properties = {}
+    if edition.ebook_access:
+        # Default availability to `unavailable`
+        link.properties["availability"] = "unavailable"
+        if edition.ebook_access == "public":
+            link.properties["availability"] = "available"
+    if edition.availability and 'borrow' in edition.availability.status:
+        # This will need to be expanded once Lenny is an option for borrowing
+        link.properties["availability"] = edition.availability.status.replace("borrow_", "")
 
     if acq.provider_name == "ia":
         link.properties['more'] = {
@@ -162,9 +170,6 @@ def ol_acquisition_to_opds_acquisition_link(
             "rel": "http://opds-spec.org/acquisition/",
             "type": "application/opds-publication+json"
         }
-
-        if edition.availability and 'borrow' in edition.availability.status:
-            link.properties["availability"] = edition.availability.status.replace("borrow_", "")
 
     if acq.price:
         amount, currency = acq.price.split(" ")


### PR DESCRIPTION
This pull request improves how OPDS acquisition links represent ebook availability and adds tests to ensure these changes work correctly. The most significant updates are in the logic that sets the `availability` property for acquisition links and the addition of a new test for this property.

**Availability property handling:**

* The `ol_acquisition_to_opds_acquisition_link` function now initializes the `properties` dictionary on OPDS acquisition links and sets the `availability` property based on the edition's access and availability status. If the ebook is public, it is marked as `available`; otherwise, it defaults to `unavailable`. For borrowable editions, the status is parsed to set the correct value.
* Redundant or misplaced logic for setting the `availability` property has been removed to streamline and clarify the code.

**Testing:**

* A new test, `test_availability`, has been added to verify that the correct `availability` value is set for different types of books (open access, lendable, and print-disabled) using real provider calls.