### PR TITLE
Add bookshelf and profile link methods to OL provider

### DIFF
--- a/pyopds2_openlibrary/__init__.py
+++ b/pyopds2_openlibrary/__init__.py
@@ -229,6 +229,22 @@ class OpenLibraryDataProvider(DataProvider):
     TITLE: str = "OpenLibrary.org OPDS Service"
     SEARCH_URL: str = "/opds/search{?query}"
 
+    @classmethod
+    def bookshelf_link(cls, host="https://archive.org"):
+        return Link(
+            rel="http://opds-spec.org/shelf",
+            href=f"{host}/services/loans/loan/?action=user_bookshelf",
+            type="application/opds+json",
+        )
+
+    @classmethod
+    def profile_link(cls, host="https://archive.org"):
+        return Link(
+            rel="profile",
+            href=f"{host}/services/loans/loan/?action=user_profile",
+            type="application/opds-profile+json",
+        )
+
     @typing.override
     @staticmethod
     def search(


### PR DESCRIPTION
This pull request adds two new class methods to the `OpenLibraryDataProvider` class to support `bookshelf` and `profile` links, enhancing the provider's OPDS navigation capabilities.

New OPDS link methods:

* Added a `bookshelf_link` class method that returns a `Link` object for the user's bookshelf, following the OPDS shelf specification.
* Added a `profile_link` class method that returns a `Link` object for the user's profile, following the OPDS profile specification.