### PR TITLE
Refactor: Implement availability check for OpenLibrary records and refine search filtering

### DIFF
--- a/pyopds2_openlibrary/__init__.py
+++ b/pyopds2_openlibrary/__init__.py
@@ -160,9 +160,12 @@ def ol_acquisition_to_opds_acquisition_link(
         link.properties["availability"] = "unavailable"
         if edition.ebook_access == "public":
             link.properties["availability"] = "available"
-    if edition.availability and 'borrow' in edition.availability.status:
-        # This will need to be expanded once Lenny is an option for borrowing
-        link.properties["availability"] = edition.availability.status.replace("borrow_", "")
+    if edition.availability:
+        status = edition.availability.status
+        if status == "open" or status == "borrow_available":
+            link.properties["availability"] = "available"
+        elif status == "private" or status == "error" or status == "borrow_unavailable":
+            link.properties["availability"] = "unavailable"
 
     if acq.provider_name == "ia":
         link.properties['more'] = {
@@ -284,8 +287,8 @@ class OpenLibraryDataProvider(DataProvider):
             offset: Number of results to skip.
             sort: Sort order for results.
             facets: Optional facets to apply. Supported facets:
-                - 'mode': 'ebooks' (default) filters to borrowable items,
-                          'everything' returns all results.
+                - 'mode': 'everything' (default) returns all results,
+                          'ebooks' filters to currently available ebook items.
         """
         fields = [
             "key", "title", "editions", "description", "providers", "author_name", "ia",
@@ -295,9 +298,9 @@ class OpenLibraryDataProvider(DataProvider):
 
         internal_query = query
         if facets:
-            mode = facets.get('mode', 'ebooks')
+            mode = facets.get('mode', 'everything')
         else:
-            mode = 'ebooks'
+            mode = 'everything'
 
         if mode == 'ebooks' and 'ebook_access:' not in internal_query:
             internal_query = f"{internal_query} ebook_access:[borrowable TO *]"


### PR DESCRIPTION
Closes #23 
This pull request introduces improvements to the Open Library data provider's search functionality, focusing on ensuring that only currently available ebooks are returned when searching in ebook mode. The changes include a new helper function for availability filtering, adjustments to the search query logic, and post-query filtering of results.

**Enhancements to ebook search availability:**

* Added a new internal helper function `_is_currently_available` to determine if a record's edition is available to read or borrow, based on edition and ebook access status.
* Updated search mode handling to correctly set the default mode and query construction, ensuring that ebook searches include only borrowable or public access editions.
* Applied post-query filtering in ebook mode to exclude records that are not currently available, using the new helper function.

I've used suggested search query https://staging.openlibrary.org/opds/search?query=According%20to%20the%20pattern&mode=ebooks

Current https://openlibrary.org/opds/search?query=According%20to%20the%20pattern&mode=ebooks
<img width="1257" height="273" alt="Image" src="https://github.com/user-attachments/assets/ac1733ae-e834-45d7-a357-2b48e17fffc1" />

Fix : `mode=everything`
<img width="1197" height="286" alt="Image" src="https://github.com/user-attachments/assets/eb74b3a2-1c8a-492f-a39e-a1267bd3e222" />

Fix : `mode=ebooks`
<img width="1236" height="270" alt="Image" src="https://github.com/user-attachments/assets/b5f44324-438b-4927-a6ab-b5f20244353b" />