### PR TITLE
Refactor availability checks to hide records without acquisition options and update query for ebooks

### DIFF
--- a/pyopds2_openlibrary/__init__.py
+++ b/pyopds2_openlibrary/__init__.py
@@ -226,25 +226,28 @@ def fetch_languages_map() -> dict[str, str]:
     return languages
 
 
-def _is_currently_available(record: OpenLibraryDataRecord) -> bool:
-    """Check if a record's edition is currently available to read/borrow.
+def _has_acquisition_options(record: OpenLibraryDataRecord) -> bool:
+    """Check if a record's edition has any acquisition options (providers).
 
-    - Public books are always available.
-    - Borrowable books are available unless explicitly marked borrow_unavailable.
-    - Books with no edition or no ebook access are excluded.
+    Books without providers have no way for the user to interact with them
+    (no borrow, no sample, no download) and should be hidden from results.
     """
+    edition = record.editions.docs[0] if record.editions and record.editions.docs else None
+    if not edition:
+        return False
+    return bool(edition.providers)
+
+
+def _is_currently_available(record: OpenLibraryDataRecord) -> bool:
+    """Check if a record's edition is currently available (not checked out)."""
     edition = record.editions.docs[0] if record.editions and record.editions.docs else None
     if not edition:
         return False
     if edition.ebook_access == "public":
         return True
-    if edition.ebook_access == "borrowable":
-        # If availability info is present and says unavailable, filter it out
-        if edition.availability and edition.availability.status == "borrow_unavailable":
-            return False
-        # Otherwise assume borrowable = available
-        return True
-    return False
+    if edition.availability and edition.availability.status == "borrow_unavailable":
+        return False
+    return True
 
 
 class OpenLibraryDataProvider(DataProvider):
@@ -303,7 +306,7 @@ class OpenLibraryDataProvider(DataProvider):
             mode = 'everything'
 
         if mode == 'ebooks' and 'ebook_access:' not in internal_query:
-            internal_query = f"{internal_query} ebook_access:[borrowable TO *]"
+            internal_query = f"{internal_query} ebook_access:[printdisabled TO *]"
 
         params = {
             "editions": "true",
@@ -326,7 +329,10 @@ class OpenLibraryDataProvider(DataProvider):
             records.append(OpenLibraryDataRecord.model_validate(doc))
 
         if mode == 'ebooks':
-            records = [r for r in records if _is_currently_available(r)]
+            # Hide books with no acquisition options (issue #23)
+            records = [r for r in records if _has_acquisition_options(r)]
+            # Sort available books before unavailable, preserving order within each group
+            records.sort(key=lambda r: (0 if _is_currently_available(r) else 1))
 
         return DataProvider.SearchResponse(
             provider=OpenLibraryDataProvider,


### PR DESCRIPTION
Closes #23 
This pull request refines the logic for filtering and presenting ebook search results in `pyopds2_openlibrary/__init__.py`. The main improvements focus on ensuring that only books with acquisition options are shown and that available books are prioritized in search results.

**Ebook filtering and sorting improvements:**
* Added a new `_has_acquisition_options` function to filter out books with no providers, ensuring only books that users can interact with are shown in results.
* Updated the search logic to use `_has_acquisition_options` for filtering, and added sorting to display available books before unavailable ones while preserving order within each group.

**Query adjustment:**
* Changed the ebook search query to use `ebook_access:[printdisabled TO *]` instead of `ebook_access:[borrowable TO *]` for more accurate filtering of accessible ebooks.


FIx's : https://github.com/ArchiveLabs/pyopds2_openlibrary/issues/23#issuecomment-3992328026
<img width="1253" height="393" alt="Screenshot 2026-03-04 at 3 26 03 AM" src="https://github.com/user-attachments/assets/009ff354-2f73-4660-8720-37ac98f22ee1" />

Fix's : https://github.com/ArchiveLabs/pyopds2_openlibrary/issues/23#issuecomment-3992331327
<img width="1344" height="314" alt="Screenshot 2026-03-04 at 3 27 36 AM" src="https://github.com/user-attachments/assets/c0c00771-c730-4e8e-a474-d4911aeb41c8" />


CC: @MarcCoquand 