### PR TITLE
Enhance OpenLibraryDataProvider and tests: Implement acquisition linkhandling, timeout management, and improve filtering logic for available editions

### DIFF
--- a/pyopds2_openlibrary/__init__.py
+++ b/pyopds2_openlibrary/__init__.py
@@ -3,6 +3,8 @@ import typing
 from typing_extensions import Literal
 from urllib.parse import urlencode
 import requests
+
+_REQUEST_TIMEOUT: float = 30.0
 from typing import List, Optional, TypedDict, cast
 from pydantic import BaseModel, Field
 
@@ -160,7 +162,7 @@ def ol_acquisition_to_opds_acquisition_link(
 
     link = Link(
         href=acq.url,
-        rel=f'http://opds-spec.org/acquisition/{acq.access}',
+        rel=f'http://opds-spec.org/acquisition/{acq.access}' if acq.access else 'http://opds-spec.org/acquisition',
         type=map_ol_format_to_mime(acq.format) if acq.format else None,
         properties={}
     )
@@ -224,7 +226,7 @@ def fetch_languages_map() -> dict[str, str]:
     Get a map of MARC language codes (as saved in Open Library search results)
     to iso_639_1 language names.
     """
-    r = requests.get("https://openlibrary.org/query.json?type=/type/language&key&identifiers&limit=1000")
+    r = requests.get("https://openlibrary.org/query.json?type=/type/language&key&identifiers&limit=1000", timeout=_REQUEST_TIMEOUT)
     r.raise_for_status()
     data = cast(List[OpenLibraryLanguageStub], r.json())
     languages = {}
@@ -246,9 +248,9 @@ def _has_acquisition_options(record: OpenLibraryDataRecord) -> bool:
     (no borrow, no sample, no download) and should be hidden from results.
     """
     edition = record.editions.docs[0] if record.editions and record.editions.docs else None
-    if not edition:
+    if not edition or not edition.providers:
         return False
-    return bool(edition.providers)
+    return any(p.url for p in edition.providers)
 
 
 def _is_currently_available(record: OpenLibraryDataRecord) -> bool:
@@ -314,6 +316,72 @@ def _has_buyable_provider(record: OpenLibraryDataRecord) -> bool:
     return False
 
 
+_EBOOK_ACCESS_RANK = {
+    "public": 3,
+    "borrowable": 2,
+    "printdisabled": 1,
+    "no_ebook": 0,
+}
+
+
+def _ebook_access_rank(ebook_access: Optional[str]) -> int:
+    """Return a numeric rank for an ebook_access value (higher = more accessible)."""
+    return _EBOOK_ACCESS_RANK.get(ebook_access or "no_ebook", 0)
+
+
+def _resolve_preferred_edition(
+    work_key: str,
+    language: str,
+    edition_fields: list[str],
+) -> Optional["OpenLibraryDataRecord.EditionDoc"]:
+    """Find a full EditionDoc for *work_key* in the preferred MARC language code.
+
+    Makes up to two requests:
+    1. Work editions endpoint to find an edition key matching *language*.
+    2. Search endpoint to get the full edition data (providers, availability, etc.).
+
+    Returns ``None`` if no matching edition is found or any request fails.
+    """
+    try:
+        r = requests.get(
+            f"{OpenLibraryDataProvider.BASE_URL}{work_key}/editions.json",
+            params={"limit": 50, "fields": "key,languages"},
+            timeout=_REQUEST_TIMEOUT,
+        )
+        r.raise_for_status()
+        preferred_olid: Optional[str] = None
+        for entry in r.json().get("entries", []):
+            langs = [lang["key"].split("/")[-1] for lang in entry.get("languages", [])]
+            if language in langs:
+                # entry["key"] is like "/books/OL27945116M"
+                preferred_olid = entry["key"].split("/")[-1]
+                break
+
+        if not preferred_olid:
+            return None
+
+        r2 = requests.get(
+            f"{OpenLibraryDataProvider.BASE_URL}/search.json",
+            params={
+                "q": f"edition_key:{preferred_olid}",
+                "editions": "true",
+                "fields": "editions," + ",".join(edition_fields),
+                "limit": 1,
+            },
+            timeout=_REQUEST_TIMEOUT,
+        )
+        r2.raise_for_status()
+        docs = r2.json().get("docs", [])
+        if not docs:
+            return None
+        edition_docs = docs[0].get("editions", {}).get("docs", [])
+        if not edition_docs:
+            return None
+        return OpenLibraryDataRecord.EditionDoc.model_validate(edition_docs[0])
+    except Exception:
+        return None
+
+
 class OpenLibraryDataProvider(DataProvider):
     """Data provider for Open Library records."""
     BASE_URL: str = "https://openlibrary.org"
@@ -358,6 +426,7 @@ class OpenLibraryDataProvider(DataProvider):
         r = requests.get(
             f"{OpenLibraryDataProvider.BASE_URL}/search.json",
             params={"q": internal_query, "limit": 0, "fields": "key"},
+            timeout=_REQUEST_TIMEOUT,
         )
         r.raise_for_status()
         return r.json().get("numFound", 0)
@@ -470,6 +539,7 @@ class OpenLibraryDataProvider(DataProvider):
         offset: int = 0,
         sort: Optional[str] = None,
         facets: Optional[dict[str, str]] = None,
+        language: str = "eng",
     ) -> DataProvider.SearchResponse:
         """
         Search Open Library.
@@ -493,6 +563,9 @@ class OpenLibraryDataProvider(DataProvider):
                       (``ebook_access:[printdisabled TO *]``), then hide
                       records without acquisition options and keep only
                       those that have at least one non-free provider.
+            language: MARC language code for the preferred edition language.
+                Defaults to ``"eng"`` (English). When multiple editions are
+                available, editions matching this language are sorted first.
         """
         fields = [
             "key", "title", "editions", "description", "providers", "author_name", "ia",
@@ -520,8 +593,11 @@ class OpenLibraryDataProvider(DataProvider):
             "limit": limit,
             **({'sort': sort} if sort else {}),
             "fields": ",".join(fields),
+            # Ask OL to prefer editions in the requested language.
+            # This works for general queries but is ignored when edition_key: is present.
+            **({'lang': language} if language else {}),
         }
-        r = requests.get(f"{OpenLibraryDataProvider.BASE_URL}/search.json", params=params)
+        r = requests.get(f"{OpenLibraryDataProvider.BASE_URL}/search.json", params=params, timeout=_REQUEST_TIMEOUT)
         r.raise_for_status()
         data = r.json()
         docs = data.get("docs", [])
@@ -535,16 +611,53 @@ class OpenLibraryDataProvider(DataProvider):
 
         total = data.get("numFound", 0)
 
+        # When the query targets a specific edition (edition_key:), OL ignores the
+        # lang param and always returns that edition.  If its language doesn't match
+        # the preference, resolve the correct edition from the work.
+        if language and "edition_key:" in query:
+            edition_fields = [
+                "key", "title", "subtitle", "description", "cover_i",
+                "ebook_access", "language", "ia", "availability", "providers",
+            ]
+            for record in records:
+                if record.editions and record.editions.docs:
+                    ed = record.editions.docs[0]
+                    if not ed.language or language not in ed.language:
+                        preferred = _resolve_preferred_edition(
+                            record.key or "", language, edition_fields
+                        )
+                        # Only substitute if the preferred edition has at least
+                        # as much ebook access as the original, so we never
+                        # silently remove a borrow/read link that was working.
+                        if preferred and _ebook_access_rank(preferred.ebook_access) >= _ebook_access_rank(ed.ebook_access):
+                            record.editions.docs[0] = preferred
+
+        # When OL returns multiple editions, move language-matching ones first
+        # (fallback for cases where lang param alone isn't sufficient).
+        if language:
+            for record in records:
+                if record.editions and record.editions.docs and len(record.editions.docs) > 1:
+                    matched = [d for d in record.editions.docs if d.language and language in d.language]
+                    others = [d for d in record.editions.docs if not (d.language and language in d.language)]
+                    if matched:
+                        record.editions.docs = matched + others
+
+        # Always filter out records with no acquisition options (issue #36).
+        # An OPDS feed is for book acquisition; without providers there is nothing
+        # the user can do with the entry. This also covers carousels that use
+        # mode='everything' and previously received no filtering.
+        records = [r for r in records if _has_acquisition_options(r)]
+
         if mode in ('ebooks', 'open_access', 'buyable'):
-            # Hide books with no acquisition options (issue #23)
-            records = [r for r in records if _has_acquisition_options(r)]
 
             if mode == 'buyable':
                 # Keep only records that have a non-free provider.
                 # This is a client-side filter (Solr has no buyable field),
                 # so total must reflect the filtered count.
                 records = [r for r in records if _has_buyable_provider(r)]
-                total = len(records)
+                # Buyable is filtered client-side; Solr cannot count it accurately,
+                # so we signal an unknown total rather than a misleading per-page count.
+                total = None
 
             # Sort available books before unavailable, preserving order within each group
             records.sort(key=lambda r: (0 if _is_currently_available(r) else 1))

--- a/tests/test_openlibrary_catalog.py
+++ b/tests/test_openlibrary_catalog.py
@@ -5,12 +5,17 @@ from urllib.parse import parse_qs, urlparse
 from unittest.mock import patch, MagicMock
 from pyopds2 import Catalog
 from pyopds2_openlibrary import (
+    _REQUEST_TIMEOUT,
     OpenLibraryDataProvider,
     OpenLibraryDataRecord,
+    _has_acquisition_options,
     _has_buyable_provider,
     _parse_price_amount,
+    _resolve_preferred_edition,
     build_facets,
     fetch_facet_counts,
+    fetch_languages_map,
+    ol_acquisition_to_opds_acquisition_link,
 )
 
 
@@ -79,7 +84,7 @@ class TestOpenLibraryCatalogCreation:
         
         # Check publications
         assert catalog.publications is not None
-        assert len(catalog.publications) == 2
+        assert len(catalog.publications) == 1
         
         # Verify first publication
         first_pub = catalog.publications[0]
@@ -104,6 +109,15 @@ class TestOpenLibraryCatalogCreation:
                     "title": "Test Book",
                     "author_name": ["Test Author"],
                     "author_key": ["OL12345A"],
+                    "editions": {
+                        "docs": [
+                            {
+                                "key": "/books/OL123M",
+                                "title": "Test Book",
+                                "providers": [{"url": "https://example.org/read"}],
+                            }
+                        ]
+                    },
                 }
             ]
         }
@@ -338,6 +352,15 @@ class TestOpenLibraryDataProvider:
                 {
                     "key": "/works/OL45804W",
                     "title": "Test Book",
+                    "editions": {
+                        "docs": [
+                            {
+                                "key": "/books/OL123M",
+                                "title": "Test Book",
+                                "providers": [{"url": "https://example.org/read"}],
+                            }
+                        ]
+                    },
                 }
             ]
         }
@@ -371,23 +394,52 @@ class TestOpenLibraryDataProvider:
         assert call_args[1]['params']['sort'] == "rating"
 
     @patch('pyopds2_openlibrary.fetch_languages_map')
-    def test_availability(self, mock_lang_map):
-        """Minimal availability test using real provider calls (no mocking of responses)."""
-        # keep language map patch to match file style; it doesn't affect the network calls
+    @patch('pyopds2_openlibrary.requests.get')
+    def test_availability(self, mock_get, mock_lang_map):
+        """Availability is computed correctly without making real API calls."""
         mock_lang_map.return_value = {"eng": "en"}
 
-        def get_availability(book_id):
-            catalog = Catalog.create(OpenLibraryDataProvider.search(book_id))
+        def get_availability(ebook_access, availability_status):
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "numFound": 1,
+                "docs": [
+                    {
+                        "key": "/works/OL1W",
+                        "title": "Test Book",
+                        "ebook_access": ebook_access,
+                        "editions": {
+                            "docs": [
+                                {
+                                    "key": "/books/OL1M",
+                                    "title": "Test Book",
+                                    "ebook_access": ebook_access,
+                                    "availability": {"status": availability_status},
+                                    "providers": [
+                                        {
+                                            "url": "https://example.org/read",
+                                            "format": "web",
+                                            "access": "borrow",
+                                            "provider_name": "ia",
+                                        }
+                                    ],
+                                }
+                            ]
+                        },
+                    }
+                ],
+            }
+            mock_response.raise_for_status.return_value = None
+            mock_get.return_value = mock_response
+
+            catalog = Catalog.create(OpenLibraryDataProvider.search("any query"))
             publication = catalog.publications[0]
             acquisition_link = next((link for link in publication.links if '/acquisition/' in link.rel), None)
             return acquisition_link.properties['availability']
 
-        standardebooks_openaccess_book = "OL51733541M"
-        assert get_availability(standardebooks_openaccess_book) == 'available'
-        internetarchive_lendable_book = "OL59176589M"
-        assert get_availability(internetarchive_lendable_book) == 'available'
-        internetarchive_printdisabled_book = "OL30032673M"
-        assert get_availability(internetarchive_printdisabled_book) == 'unavailable'
+        assert get_availability("public", "open") == 'available'
+        assert get_availability("printdisabled", "borrow_available") == 'available'
+        assert get_availability("printdisabled", "borrow_unavailable") == 'unavailable'
 
 
 def _record_with_providers(*providers: OpenLibraryDataRecord.EditionProvider) -> OpenLibraryDataRecord:
@@ -401,6 +453,83 @@ def _record_with_providers(*providers: OpenLibraryDataRecord.EditionProvider) ->
         title="Work",
         editions=OpenLibraryDataRecord.EditionsResultSet(docs=[edition]),
     )
+
+
+class TestHasAcquisitionOptions:
+    def test_returns_false_when_edition_providers_is_none(self):
+        record = OpenLibraryDataRecord(
+            key="/works/OL10W",
+            title="No providers field",
+            editions=OpenLibraryDataRecord.EditionsResultSet(
+                docs=[OpenLibraryDataRecord.EditionDoc(key="/books/OL10M", title="Edition", providers=None)]
+            ),
+        )
+        assert _has_acquisition_options(record) is False
+
+    def test_returns_false_when_edition_providers_is_empty(self):
+        record = OpenLibraryDataRecord(
+            key="/works/OL11W",
+            title="Empty providers",
+            editions=OpenLibraryDataRecord.EditionsResultSet(
+                docs=[OpenLibraryDataRecord.EditionDoc(key="/books/OL11M", title="Edition", providers=[])]
+            ),
+        )
+        assert _has_acquisition_options(record) is False
+
+    def test_returns_false_when_all_provider_urls_are_none(self):
+        record = _record_with_providers(
+            OpenLibraryDataRecord.EditionProvider(provider_name="a", url=None),
+            OpenLibraryDataRecord.EditionProvider(provider_name="b", url=None),
+        )
+        assert _has_acquisition_options(record) is False
+
+    def test_returns_false_when_multiple_providers_all_urls_none(self):
+        record = _record_with_providers(
+            OpenLibraryDataRecord.EditionProvider(provider_name="a", access="borrow", url=None),
+            OpenLibraryDataRecord.EditionProvider(provider_name="b", access="open-access", url=None),
+            OpenLibraryDataRecord.EditionProvider(provider_name="c", format="epub", url=None),
+        )
+        assert _has_acquisition_options(record) is False
+
+    def test_returns_true_when_at_least_one_provider_has_url(self):
+        record = _record_with_providers(
+            OpenLibraryDataRecord.EditionProvider(provider_name="a", url="https://example.org/a"),
+        )
+        assert _has_acquisition_options(record) is True
+
+    def test_returns_true_when_mix_of_none_and_valid_urls(self):
+        record = _record_with_providers(
+            OpenLibraryDataRecord.EditionProvider(provider_name="a", url=None),
+            OpenLibraryDataRecord.EditionProvider(provider_name="b", url="https://example.org/b"),
+        )
+        assert _has_acquisition_options(record) is True
+
+    def test_returns_false_when_record_has_no_editions(self):
+        record = OpenLibraryDataRecord(key="/works/OL12W", title="No editions")
+        assert _has_acquisition_options(record) is False
+
+
+class TestAcquisitionLinkRelFallback:
+    def test_access_none_uses_generic_acquisition_rel(self):
+        edition = OpenLibraryDataRecord.EditionDoc(key="/books/OL20M", title="Edition")
+        acq = OpenLibraryDataRecord.EditionProvider(url="https://example.org/generic", access=None)
+
+        link = ol_acquisition_to_opds_acquisition_link(edition, acq)
+        assert link.rel == "http://opds-spec.org/acquisition"
+
+    def test_access_borrow_uses_borrow_rel(self):
+        edition = OpenLibraryDataRecord.EditionDoc(key="/books/OL21M", title="Edition")
+        acq = OpenLibraryDataRecord.EditionProvider(url="https://example.org/borrow", access="borrow")
+
+        link = ol_acquisition_to_opds_acquisition_link(edition, acq)
+        assert link.rel == "http://opds-spec.org/acquisition/borrow"
+
+    def test_access_open_access_uses_open_access_rel(self):
+        edition = OpenLibraryDataRecord.EditionDoc(key="/books/OL22M", title="Edition")
+        acq = OpenLibraryDataRecord.EditionProvider(url="https://example.org/open", access="open-access")
+
+        link = ol_acquisition_to_opds_acquisition_link(edition, acq)
+        assert link.rel == "http://opds-spec.org/acquisition/open-access"
 
 
 class TestPriceAndBuyableHelpers:
@@ -690,8 +819,8 @@ class TestSearchModeHandling:
         self._mock_search_response(mock_get)
 
         result = OpenLibraryDataProvider.search("cats", facets={"mode": "buyable"})
-        assert result.total == len(result.records)
-        assert result.total == 1
+        assert result.total is None
+        assert len(result.records) == 1
         assert all(_has_buyable_provider(r) for r in result.records)
 
     @patch("pyopds2_openlibrary.requests.get")
@@ -709,3 +838,302 @@ class TestSearchModeHandling:
         result = OpenLibraryDataProvider.search("cats", facets={"mode": "ebooks"})
         assert result.records[0].title == "Paid Available"
         assert result.records[1].title == "Free Unavailable"
+
+
+class TestSearchAcquisitionFilterAllModes:
+    @staticmethod
+    def _doc_with_providers(
+        key: str,
+        title: str,
+        providers: list[dict] | None,
+        description: str | None = None,
+    ) -> dict:
+        return {
+            "key": key,
+            "title": title,
+            "description": description,
+            "ebook_access": "printdisabled",
+            "editions": {
+                "docs": [
+                    {
+                        "key": key.replace("/works", "/books").replace("W", "M"),
+                        "title": title,
+                        "providers": providers,
+                    }
+                ]
+            },
+        }
+
+    def _mock_response_with_mixed_acquisition(self, mock_get):
+        docs = [
+            self._doc_with_providers(
+                key="/works/OL31W",
+                title="No providers",
+                providers=[],
+            ),
+            self._doc_with_providers(
+                key="/works/OL32W",
+                title="Null urls only",
+                providers=[{"url": None}, {"url": None}],
+            ),
+            self._doc_with_providers(
+                key="/works/OL33W",
+                title="Valid provider",
+                providers=[{"url": "https://example.org/read", "access": "borrow"}],
+            ),
+            self._doc_with_providers(
+                key="/works/OL34W",
+                title="Has description only",
+                providers=[],
+                description="Should still be filtered",
+            ),
+        ]
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"numFound": 44, "docs": docs}
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+    @patch("pyopds2_openlibrary.requests.get")
+    def test_mode_everything_excludes_record_with_empty_providers(self, mock_get):
+        self._mock_response_with_mixed_acquisition(mock_get)
+
+        result = OpenLibraryDataProvider.search("cats", facets={"mode": "everything"})
+        titles = [r.title for r in result.records]
+        assert "No providers" not in titles
+
+    @patch("pyopds2_openlibrary.requests.get")
+    def test_mode_everything_excludes_record_with_all_null_provider_urls(self, mock_get):
+        self._mock_response_with_mixed_acquisition(mock_get)
+
+        result = OpenLibraryDataProvider.search("cats", facets={"mode": "everything"})
+        titles = [r.title for r in result.records]
+        assert "Null urls only" not in titles
+
+    @patch("pyopds2_openlibrary.requests.get")
+    def test_mode_everything_keeps_record_with_valid_provider_url(self, mock_get):
+        self._mock_response_with_mixed_acquisition(mock_get)
+
+        result = OpenLibraryDataProvider.search("cats", facets={"mode": "everything"})
+        titles = [r.title for r in result.records]
+        assert "Valid provider" in titles
+
+    @patch("pyopds2_openlibrary.requests.get")
+    def test_mode_everything_excludes_described_record_without_providers(self, mock_get):
+        self._mock_response_with_mixed_acquisition(mock_get)
+
+        result = OpenLibraryDataProvider.search("cats", facets={"mode": "everything"})
+        titles = [r.title for r in result.records]
+        assert "Has description only" not in titles
+
+    @patch("pyopds2_openlibrary.requests.get")
+    def test_mode_ebooks_excludes_record_without_providers(self, mock_get):
+        self._mock_response_with_mixed_acquisition(mock_get)
+
+        result = OpenLibraryDataProvider.search("cats", facets={"mode": "ebooks"})
+        titles = [r.title for r in result.records]
+        assert "No providers" not in titles
+
+    @patch("pyopds2_openlibrary.requests.get")
+    def test_mode_open_access_excludes_record_without_providers(self, mock_get):
+        self._mock_response_with_mixed_acquisition(mock_get)
+
+        result = OpenLibraryDataProvider.search("cats", facets={"mode": "open_access"})
+        titles = [r.title for r in result.records]
+        assert "No providers" not in titles
+
+
+class TestRequestTimeoutUsage:
+    @patch("pyopds2_openlibrary.requests.get")
+    def test_fetch_languages_map_passes_timeout(self, mock_get):
+        fetch_languages_map.cache_clear()
+        mock_response = MagicMock()
+        mock_response.json.return_value = []
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        fetch_languages_map()
+
+        assert mock_get.call_args[1]["timeout"] == 30.0
+        assert mock_get.call_args[1]["timeout"] == _REQUEST_TIMEOUT
+
+    @patch("pyopds2_openlibrary.requests.get")
+    def test_resolve_preferred_edition_editions_request_passes_timeout(self, mock_get):
+        first_response = MagicMock()
+        first_response.raise_for_status.return_value = None
+        first_response.json.return_value = {
+            "entries": [
+                {
+                    "key": "/books/OL40M",
+                    "languages": [{"key": "/languages/eng"}],
+                }
+            ]
+        }
+
+        second_response = MagicMock()
+        second_response.raise_for_status.return_value = None
+        second_response.json.return_value = {
+            "docs": [
+                {
+                    "editions": {
+                        "docs": [
+                            {
+                                "key": "/books/OL40M",
+                                "title": "Preferred",
+                                "providers": [{"url": "https://example.org/book"}],
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+        mock_get.side_effect = [first_response, second_response]
+
+        _resolve_preferred_edition("/works/OL40W", "eng", ["key", "title", "providers"])
+
+        assert mock_get.call_args_list[0].kwargs["timeout"] == 30.0
+        assert mock_get.call_args_list[0].kwargs["timeout"] == _REQUEST_TIMEOUT
+
+    @patch("pyopds2_openlibrary.requests.get")
+    def test_resolve_preferred_edition_search_request_passes_timeout(self, mock_get):
+        first_response = MagicMock()
+        first_response.raise_for_status.return_value = None
+        first_response.json.return_value = {
+            "entries": [
+                {
+                    "key": "/books/OL41M",
+                    "languages": [{"key": "/languages/eng"}],
+                }
+            ]
+        }
+
+        second_response = MagicMock()
+        second_response.raise_for_status.return_value = None
+        second_response.json.return_value = {
+            "docs": [
+                {
+                    "editions": {
+                        "docs": [
+                            {
+                                "key": "/books/OL41M",
+                                "title": "Preferred",
+                                "providers": [{"url": "https://example.org/book"}],
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+        mock_get.side_effect = [first_response, second_response]
+
+        _resolve_preferred_edition("/works/OL41W", "eng", ["key", "title", "providers"])
+
+        assert mock_get.call_args_list[1].kwargs["timeout"] == 30.0
+        assert mock_get.call_args_list[1].kwargs["timeout"] == _REQUEST_TIMEOUT
+
+    @patch("pyopds2_openlibrary.requests.get")
+    def test_count_for_mode_passes_timeout(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"numFound": 1}
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        OpenLibraryDataProvider._count_for_mode("cats", "everything")
+
+        assert mock_get.call_args[1]["timeout"] == 30.0
+        assert mock_get.call_args[1]["timeout"] == _REQUEST_TIMEOUT
+
+    @patch("pyopds2_openlibrary.requests.get")
+    def test_search_passes_timeout(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "numFound": 1,
+            "docs": [
+                {
+                    "key": "/works/OL42W",
+                    "title": "Book",
+                    "editions": {
+                        "docs": [
+                            {
+                                "key": "/books/OL42M",
+                                "title": "Book",
+                                "providers": [{"url": "https://example.org/book"}],
+                            }
+                        ]
+                    },
+                }
+            ],
+        }
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        OpenLibraryDataProvider.search("cats", facets={"mode": "everything"})
+
+        assert mock_get.call_args[1]["timeout"] == 30.0
+        assert mock_get.call_args[1]["timeout"] == _REQUEST_TIMEOUT
+
+
+class TestSearchTotalsByMode:
+    @staticmethod
+    def _mock_docs_with_buyable_and_non_buyable():
+        return [
+            {
+                "key": "/works/OL51W",
+                "title": "Paid",
+                "ebook_access": "printdisabled",
+                "editions": {
+                    "docs": [
+                        {
+                            "key": "/books/OL51M",
+                            "title": "Paid",
+                            "availability": {"status": "borrow_available"},
+                            "providers": [{"url": "https://example.org/paid", "price": "5.00 USD"}],
+                        }
+                    ]
+                },
+            },
+            {
+                "key": "/works/OL52W",
+                "title": "Free",
+                "ebook_access": "printdisabled",
+                "editions": {
+                    "docs": [
+                        {
+                            "key": "/books/OL52M",
+                            "title": "Free",
+                            "availability": {"status": "borrow_available"},
+                            "providers": [{"url": "https://example.org/free", "price": "0.00 USD"}],
+                        }
+                    ]
+                },
+            },
+        ]
+
+    @patch("pyopds2_openlibrary.requests.get")
+    def test_mode_buyable_total_is_none(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"numFound": 88, "docs": self._mock_docs_with_buyable_and_non_buyable()}
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        result = OpenLibraryDataProvider.search("cats", facets={"mode": "buyable"})
+        assert result.total is None
+
+    @patch("pyopds2_openlibrary.requests.get")
+    def test_mode_ebooks_total_uses_openlibrary_numfound(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"numFound": 77, "docs": self._mock_docs_with_buyable_and_non_buyable()}
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        result = OpenLibraryDataProvider.search("cats", facets={"mode": "ebooks"})
+        assert result.total == 77
+
+    @patch("pyopds2_openlibrary.requests.get")
+    def test_mode_everything_total_uses_openlibrary_numfound(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"numFound": 66, "docs": self._mock_docs_with_buyable_and_non_buyable()}
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        result = OpenLibraryDataProvider.search("cats", facets={"mode": "everything"})
+        assert result.total == 66


### PR DESCRIPTION
Closes #36


This pull request enhances the Open Library data provider by improving language handling for edition selection, making HTTP requests more robust, and ensuring that only books with acquisition options are included in results. The most significant changes are the addition of a preferred language parameter to search, logic to select the most appropriate edition based on language, and consistent request timeouts.

**Language preference and edition selection:**

* Added a `language` parameter (defaulting to `"eng"`) to the `search` method, allowing clients to specify a preferred MARC language code for edition selection. Editions in the requested language are prioritized in results. [[1]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113R542) [[2]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113R566-R568) [[3]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113R596-R600)
* Implemented `_resolve_preferred_edition` to fetch and substitute the best-matching edition in the preferred language when a specific edition is requested but does not match the language preference. Editions are only substituted if they offer at least as much ebook access as the original. [[1]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113R319-R384) [[2]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113L538-R660)
* When multiple editions are present, editions matching the preferred language are moved to the front of the list.

**Acquisition options and filtering:**

* Improved filtering to always exclude records without acquisition options (providers), ensuring OPDS feeds only include actionable entries. The logic now checks for the presence of provider URLs, not just the existence of provider objects. [[1]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113L249-R253) [[2]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113L538-R660)
* For the "buyable" mode, the total count is set to `None` to signal that the filtered total cannot be accurately determined server-side.

**HTTP request robustness:**

* Added a consistent timeout (`_REQUEST_TIMEOUT`) to all `requests.get` calls to prevent indefinite hangs on network requests. [[1]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113R6-R7) [[2]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113L227-R229) [[3]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113R429) [[4]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113R596-R600)

**Other improvements:**

* The `ol_acquisition_to_opds_acquisition_link` function now handles missing `access` fields more gracefully by defaulting the `rel` attribute.