### PR TITLE
Enhance OpenLibraryDataRecord and OpenLibraryDataProvider with access options and improved description handling

### DIFF
--- a/pyopds2_openlibrary/__init__.py
+++ b/pyopds2_openlibrary/__init__.py
@@ -211,12 +211,18 @@ class OpenLibraryDataRecord(BookSharedDoc, DataProviderRecord):
         edition = self.editions.docs[0] if self.editions and self.editions.docs else None
         book = edition or self
 
+        desc = book.description
+        if not desc and self.description:
+            langs = book.language or self.language or []
+            if "eng" in langs:
+                desc = self.description
+
         return Metadata(
             type=self.type,
             title=book.title or self.title or "Untitled",
             subtitle=book.subtitle,
             author=get_authors(),
-            description=strip_markdown(book.description) if book.description else None,
+            description=strip_markdown(desc) if desc else None,
             language=[lang for marc_lang in (book.language or []) if (lang := marc_language_to_iso_639_1(marc_lang))],
             # TODO: Use the edition-specific pagecount
             numberOfPages=self.number_of_pages_median,
@@ -808,7 +814,6 @@ def _align_editions_to_language(
 _AVAILABILITY_MODES: list[tuple[str, str]] = [
     ("everything",     "Everything"),
     ("ebooks",         "Available to Borrow"),
-    ("print_disabled", "Print Disabled"),
     ("open_access",    "Open Access"),
     ("buyable",        "Available for Purchase"),
 ]
@@ -942,6 +947,38 @@ def _build_media_type_links(
     return links
 
 
+# Access options for the Access facet group (OPDS 2.0 §2.4).
+# "general" (default) hides print-disabled content; "print_disabled" shows only that content.
+_ACCESS_OPTIONS: list[tuple[str, str]] = [
+    ("general",        "General"),
+    ("print_disabled", "Print Disabled"),
+]
+
+
+def _build_access_links(
+    access: Optional[str],
+    href_fn: typing.Callable[[str], str],
+) -> list[dict]:
+    """Build the list of access facet link dicts per OPDS 2.0 §2.4.
+
+    Two options: 'General' (default, excludes print-disabled) and 'Print Disabled'
+    (shows only print-disabled content). Print-disabled is hidden by default.
+    """
+    active = access or "general"
+    links = []
+    for ac_code, label in _ACCESS_OPTIONS:
+        link: dict = {
+            "title": label,
+            "href": href_fn(ac_code),
+            "type": "application/opds+json",
+        }
+        if ac_code == active:
+            link["rel"] = "self"
+            link.setdefault("properties", {})["active"] = True
+        links.append(link)
+    return links
+
+
 # ---------------------------------------------------------------------------
 # Homepage carousel group helpers
 # ---------------------------------------------------------------------------
@@ -984,6 +1021,23 @@ def _kids_group(ea: str) -> tuple[str, str, str]:
     return ("Kids", f'{ea} trending_score_hourly_sum:[1 TO *] {_KIDS_SUBJECT_FILTER} -subject:"content_warning:cover"', "random.hourly")
 
 
+_GROUP_DESCRIPTIONS: dict[str, str] = {
+    "Standard Ebooks": (
+        "Standard Ebooks is a volunteer-run project that produces free, carefully "
+        "typeset public-domain ebooks formatted to a consistent standard for modern "
+        "e-readers."
+    ),
+    "Classic Books": (
+        "Beloved works from before 1950 that have been digitized and made freely "
+        "available as ebooks."
+    ),
+    "Kids": (
+        "Stories, picture books, and non-fiction for young readers, available on "
+        "Open Library."
+    ),
+}
+
+
 class OpenLibraryDataProvider(DataProvider):
     """Data provider for Open Library records."""
     BASE_URL: str = "https://openlibrary.org"
@@ -1022,10 +1076,10 @@ class OpenLibraryDataProvider(DataProvider):
         internal_query = query
         if mode == 'ebooks' and 'ebook_access:' not in internal_query:
             internal_query = f"{internal_query} ebook_access:[printdisabled TO *]"
-        elif mode == 'print_disabled' and 'ebook_access:' not in internal_query:
-            internal_query = f"{internal_query} ebook_access:printdisabled"
         elif mode == 'open_access' and 'ebook_access:' not in internal_query:
             internal_query = f"{internal_query} ebook_access:public"
+        elif mode == 'print_disabled' and 'ebook_access:' not in internal_query:
+            internal_query = f"{internal_query} ebook_access:printdisabled"
 
         r = _get(
             f"{OpenLibraryDataProvider.BASE_URL}/search.json",
@@ -1085,6 +1139,7 @@ class OpenLibraryDataProvider(DataProvider):
         total: Optional[int] = None,
         availability_counts: Optional[dict[str, int]] = None,
         media_type: Optional[str] = None,
+        access: Optional[str] = None,
     ) -> list[dict]:
         """Build OPDS 2.0 facets for availability and language filtering.
 
@@ -1116,6 +1171,7 @@ class OpenLibraryDataProvider(DataProvider):
             mode_val: str = mode,
             lang_val: Optional[str] = language,
             mt_val: Optional[str] = media_type,
+            ac_val: Optional[str] = access,
         ) -> str:
             # Strip ebook_access filters from the query for "everything" mode
             # so the facet link truly returns all results regardless of how
@@ -1132,6 +1188,8 @@ class OpenLibraryDataProvider(DataProvider):
                 params["language"] = lang_val
             if mt_val:
                 params["media_type"] = mt_val
+            if ac_val and ac_val != "general":
+                params["access"] = ac_val
             if title:
                 params["title"] = title
             return f"{base_url}/search?{urlencode(params)}"
@@ -1163,6 +1221,13 @@ class OpenLibraryDataProvider(DataProvider):
                     href_fn=lambda mt: search_href(mt_val=mt),
                 ),
             },
+            {
+                "metadata": {"title": "Access"},
+                "links": _build_access_links(
+                    access=access,
+                    href_fn=lambda ac: search_href(ac_val=ac),
+                ),
+            },
         ]
 
     @staticmethod
@@ -1171,6 +1236,7 @@ class OpenLibraryDataProvider(DataProvider):
         mode: str = "everything",
         language: Optional[str] = None,
         media_type: Optional[str] = None,
+        access: Optional[str] = None,
     ) -> list[dict]:
         """Build Availability, Language, and Media Type facet groups for the OPDS homepage.
 
@@ -1194,6 +1260,8 @@ class OpenLibraryDataProvider(DataProvider):
                 params["language"] = language
             if media_type:
                 params["media_type"] = media_type
+            if access and access != "general":
+                params["access"] = access
             return f"{base_url}/?{urlencode(params)}" if params else f"{base_url}/"
 
         def lang_href(lang: Optional[str]) -> str:
@@ -1204,6 +1272,8 @@ class OpenLibraryDataProvider(DataProvider):
                 params["language"] = lang
             if media_type:
                 params["media_type"] = media_type
+            if access and access != "general":
+                params["access"] = access
             return f"{base_url}/?{urlencode(params)}" if params else f"{base_url}/"
 
         def mt_href(mt: Optional[str]) -> str:
@@ -1214,6 +1284,20 @@ class OpenLibraryDataProvider(DataProvider):
                 params["language"] = language
             if mt:
                 params["media_type"] = mt
+            if access and access != "general":
+                params["access"] = access
+            return f"{base_url}/?{urlencode(params)}" if params else f"{base_url}/"
+
+        def ac_href(ac: str) -> str:
+            params: dict[str, str] = {}
+            if mode != "everything":
+                params["mode"] = mode
+            if language:
+                params["language"] = language
+            if media_type:
+                params["media_type"] = media_type
+            if ac != "general":
+                params["access"] = ac
             return f"{base_url}/?{urlencode(params)}" if params else f"{base_url}/"
 
         return [
@@ -1239,6 +1323,13 @@ class OpenLibraryDataProvider(DataProvider):
                     href_fn=mt_href,
                 ),
             },
+            {
+                "metadata": {"title": "Access"},
+                "links": _build_access_links(
+                    access=access,
+                    href_fn=ac_href,
+                ),
+            },
         ]
 
     @staticmethod
@@ -1250,6 +1341,7 @@ class OpenLibraryDataProvider(DataProvider):
         media_type: Optional[str] = None,
         page: int = 1,
         limit: int = 25,
+        access: Optional[str] = None,
     ) -> list[dict]:
         """Build Availability, Language, and Media Type facet groups for an author catalog page.
 
@@ -1261,6 +1353,7 @@ class OpenLibraryDataProvider(DataProvider):
             mode_val: str = mode,
             lang_val: Optional[str] = language,
             mt_val: Optional[str] = media_type,
+            ac_val: Optional[str] = access,
         ) -> str:
             params: dict[str, str] = {}
             if page > 1:
@@ -1273,6 +1366,8 @@ class OpenLibraryDataProvider(DataProvider):
                 params["language"] = lang_val
             if mt_val:
                 params["media_type"] = mt_val
+            if ac_val and ac_val != "general":
+                params["access"] = ac_val
             return f"{base_url}/authors/{olid}?{urlencode(params)}" if params else f"{base_url}/authors/{olid}"
 
         return [
@@ -1296,6 +1391,13 @@ class OpenLibraryDataProvider(DataProvider):
                 "links": _build_media_type_links(
                     media_type=media_type,
                     href_fn=lambda mt: author_href(mt_val=mt),
+                ),
+            },
+            {
+                "metadata": {"title": "Access"},
+                "links": _build_access_links(
+                    access=access,
+                    href_fn=lambda ac: author_href(ac_val=ac),
                 ),
             },
         ]
@@ -1380,6 +1482,7 @@ class OpenLibraryDataProvider(DataProvider):
     def _home_page_href(
         base: str, mode: str, language: Optional[str], page: int,
         media_type: Optional[str] = None,
+        access: Optional[str] = None,
     ) -> str:
         """Build a homepage href with pagination."""
         params: dict[str, str] = {}
@@ -1389,6 +1492,8 @@ class OpenLibraryDataProvider(DataProvider):
             params["language"] = language
         if media_type:
             params["media_type"] = media_type
+        if access and access != "general":
+            params["access"] = access
         if page > 1:
             params["page"] = str(page)
         return f"{base}/?{urlencode(params)}" if params else f"{base}/"
@@ -1402,6 +1507,7 @@ class OpenLibraryDataProvider(DataProvider):
         page: int = 1,
         featured_subjects: Optional[list[dict[str, str]]] = None,
         media_type: Optional[str] = None,
+        access: Optional[str] = None,
     ) -> dict:
         """Build a complete OPDS 2.0 homepage catalog dict.
 
@@ -1443,9 +1549,10 @@ class OpenLibraryDataProvider(DataProvider):
                 resp = cls.search(
                     query=query, sort=sort, limit=25,
                     language=language, facets={"mode": mode}, title=title,
-                    media_type=media_type,
+                    media_type=media_type, access=access,
                 )
-                return Catalog.create(metadata=Metadata(title=title), response=resp)
+                desc = _GROUP_DESCRIPTIONS.get(title)
+                return Catalog.create(metadata=Metadata(title=title, description=desc), response=resp)
             except Exception:
                 return None
 
@@ -1491,23 +1598,23 @@ class OpenLibraryDataProvider(DataProvider):
 
         # Links
         links = [
-            Link(rel="self", href=cls._home_page_href(base, mode, language, page, media_type), type=media),
+            Link(rel="self", href=cls._home_page_href(base, mode, language, page, media_type, access), type=media),
             Link(rel="start", href=f"{base}/", type=media),
             Link(rel="search", href=f"{base}/search{{?query}}", type=media, templated=True),
             cls.bookshelf_link(),
             cls.profile_link(),
         ]
         if has_next:
-            links.append(Link(rel="next", href=cls._home_page_href(base, mode, language, page + 1, media_type), type=media))
+            links.append(Link(rel="next", href=cls._home_page_href(base, mode, language, page + 1, media_type, access), type=media))
         if page > 1:
-            links.append(Link(rel="previous", href=cls._home_page_href(base, mode, language, page - 1, media_type), type=media))
+            links.append(Link(rel="previous", href=cls._home_page_href(base, mode, language, page - 1, media_type, access), type=media))
 
         catalog = Catalog(
             metadata=Metadata(title="Open Library"),
             publications=[],
             navigation=navigation,
             groups=loaded_groups,
-            facets=cls.build_home_facets(base, mode, language, media_type),
+            facets=cls.build_home_facets(base, mode, language, media_type, access=access),
             links=links,
         )
         return catalog.model_dump()
@@ -1524,6 +1631,7 @@ class OpenLibraryDataProvider(DataProvider):
         title: Optional[str] = None,
         require_cover: bool = True,
         media_type: Optional[str] = None,
+        access: Optional[str] = None,
     ) -> DataProvider.SearchResponse:
         """
         Search Open Library.
@@ -1640,12 +1748,25 @@ class OpenLibraryDataProvider(DataProvider):
         if media_type == "ebook":
             records = [r for r in records if not r.id_librivox]
 
-        if mode in ('ebooks', 'print_disabled', 'open_access', 'buyable'):
+        # Access filter: control print-disabled visibility.
+        # "general" (default) hides print-disabled books; "print_disabled" shows only them.
+        if access == "print_disabled":
+            records = [r for r in records
+                       if _get_edition_ebook_access(r) == "printdisabled"
+                       or r.ebook_access == "printdisabled"]
+        else:
+            records = [r for r in records
+                       if _get_edition_ebook_access(r) != "printdisabled"
+                       and r.ebook_access != "printdisabled"]
+
+        if access != "print_disabled" and mode in ('ebooks', 'print_disabled', 'open_access', 'buyable'):
             if mode == 'buyable':
                 # Keep only records that have a non-free provider.
                 # This is a client-side filter (Solr has no buyable field).
                 records = [r for r in records if _has_buyable_provider(r)]
             # Sort available books before unavailable, preserving order within each group
+            records.sort(key=lambda r: (0 if _is_currently_available(r) else 1))
+        elif access == "print_disabled":
             records.sort(key=lambda r: (0 if _is_currently_available(r) else 1))
 
         # Strict post-filter: enforce ebook_access boundaries after all edition resolution.
@@ -1655,7 +1776,7 @@ class OpenLibraryDataProvider(DataProvider):
         # "borrowable" should still appear in open_access mode — the Solr query already
         # guaranteed the work is public. For ebooks mode, the work-level OR means a
         # borrowable work whose language-swapped edition is public will still be included.
-        if mode in _EBOOK_MODE_ALLOWED:
+        if access != "print_disabled" and mode in _EBOOK_MODE_ALLOWED:
             allowed = _EBOOK_MODE_ALLOWED[mode]
             records = [r for r in records if _get_edition_ebook_access(r) in allowed or r.ebook_access in allowed]
 

--- a/pyopds2_openlibrary/__init__.py
+++ b/pyopds2_openlibrary/__init__.py
@@ -1028,7 +1028,7 @@ _GROUP_DESCRIPTIONS: dict[str, str] = {
         "e-readers."
     ),
     "Classic Books": (
-        "Beloved works from before 1950 that have been digitized and made freely "
+        "Beloved works from before 1950 that have been digitized and made available to the public"
         "available as ebooks."
     ),
     "Kids": (

--- a/tests/test_new_functions.py
+++ b/tests/test_new_functions.py
@@ -1,0 +1,385 @@
+"""Test cases for newly added functions: Latin names, author bios, Markdown stripping, and LibriVox support."""
+
+from unittest.mock import MagicMock, patch
+import pytest
+
+import pyopds2_openlibrary as openlibrary
+from pyopds2_openlibrary import (
+    OpenLibraryDataRecord,
+    _is_latin_name,
+    _latin_name_for_author,
+    fetch_author_bio,
+    strip_markdown,
+)
+
+
+class TestIsLatinName:
+    """Test Latin script detection using Unicode character names."""
+
+    def test_pure_latin_ascii_returns_true(self):
+        """ASCII letters are Latin script."""
+        assert _is_latin_name("John") is True
+        assert _is_latin_name("Smith") is True
+        assert _is_latin_name("Hello World") is True
+
+    def test_latin_extended_returns_true(self):
+        """Latin Extended characters (accented, etc.) are Latin script."""
+        assert _is_latin_name("José") is True
+        assert _is_latin_name("François") is True
+        assert _is_latin_name("Müller") is True
+        assert _is_latin_name("Łąkę") is True
+
+    def test_cyrillic_returns_false(self):
+        """Cyrillic script should return False."""
+        assert _is_latin_name("Иван") is False
+        assert _is_latin_name("Петров") is False
+
+    def test_greek_returns_false(self):
+        """Greek script should return False."""
+        assert _is_latin_name("Αλέξανδρος") is False
+
+    def test_arabic_returns_false(self):
+        """Arabic script should return False."""
+        assert _is_latin_name("أحمد") is False
+
+    def test_chinese_returns_false(self):
+        """CJK characters should return False."""
+        assert _is_latin_name("王小明") is False
+
+    def test_mixed_with_numbers_returns_true(self):
+        """Numbers are not alphabetic and should be ignored."""
+        assert _is_latin_name("Name123") is True
+        assert _is_latin_name("Test42") is True
+
+    def test_empty_string_returns_true(self):
+        """Empty string has no non-Latin alphabetic characters."""
+        assert _is_latin_name("") is True
+
+    def test_only_punctuation_returns_true(self):
+        """Punctuation is not alphabetic."""
+        assert _is_latin_name("!@#$%^&*()") is True
+        assert _is_latin_name("--dash--") is True
+
+    def test_mixed_latin_and_cyrillic_returns_false(self):
+        """If any non-Latin alphabetic characters are present, return False."""
+        assert _is_latin_name("Name Иван") is False
+
+
+class TestLatinNameForAuthor:
+    """Test fetching Latin-script names for authors."""
+
+    def test_already_latin_name_returns_unchanged(self):
+        """If the current name is already Latin, return it unchanged."""
+        assert _latin_name_for_author("OL123A", "John Smith") == "John Smith"
+
+    @patch("pyopds2_openlibrary._get")
+    def test_fetches_personal_name_when_current_is_non_latin(self, mock_get):
+        """Fetch author data when current name is non-Latin."""
+        response = MagicMock()
+        response.json.return_value = {
+            "personal_name": "Ivan Petrov",
+            "name": "Иван Петров",
+        }
+        mock_get.return_value = response
+        
+        result = _latin_name_for_author("OL123A", "Иван Петров")
+        
+        assert result == "Ivan Petrov"
+        mock_get.assert_called_once_with("https://openlibrary.org/authors/OL123A.json")
+
+    @patch("pyopds2_openlibrary._get")
+    def test_fallback_to_current_when_no_latin_personal_name(self, mock_get):
+        """If personal_name is not Latin, fall back to current name."""
+        # Clear cache to ensure clean test
+        openlibrary._latin_author_cache.clear()
+        
+        response = MagicMock()
+        response.json.return_value = {
+            "personal_name": "Иван",
+            "name": "Иван Петров",
+        }
+        mock_get.return_value = response
+        
+        result = _latin_name_for_author("OL_UNIQUE_123", "Иван Петров")
+        
+        assert result == "Иван Петров"
+
+    @patch("pyopds2_openlibrary._get")
+    def test_caches_result(self, mock_get):
+        """Cache the result so future calls don't need to fetch."""
+        response = MagicMock()
+        response.json.return_value = {
+            "personal_name": "Latin Name",
+            "name": "Кириллица",
+        }
+        mock_get.return_value = response
+        
+        # First call should fetch
+        result1 = _latin_name_for_author("OL456A", "Кириллица")
+        # Second call should use cache
+        result2 = _latin_name_for_author("OL456A", "Кириллица")
+        
+        assert result1 == result2 == "Latin Name"
+        mock_get.assert_called_once()
+
+    @patch("pyopds2_openlibrary._get")
+    def test_handles_fetch_error_gracefully(self, mock_get):
+        """On any error, return the current name."""
+        mock_get.side_effect = Exception("API error")
+        
+        result = _latin_name_for_author("OL789A", "Кириллица")
+        
+        assert result == "Кириллица"
+
+
+class TestFetchAuthorBio:
+    """Test fetching author bios from OpenLibrary."""
+
+    @patch("pyopds2_openlibrary._get")
+    def test_fetch_author_bio_success(self, mock_get):
+        """Fetch author name and bio successfully."""
+        response = MagicMock()
+        response.json.return_value = {
+            "name": "John Doe",
+            "bio": "An American author.",
+        }
+        mock_get.return_value = response
+        
+        name, bio = fetch_author_bio("OL123A")
+        
+        assert name == "John Doe"
+        assert bio == "An American author."
+
+    @patch("pyopds2_openlibrary._get")
+    def test_fetch_author_bio_with_personal_name(self, mock_get):
+        """Use personal_name if name is not available."""
+        response = MagicMock()
+        response.json.return_value = {
+            "personal_name": "John Michael Doe",
+            "bio": "Author biography.",
+        }
+        mock_get.return_value = response
+        
+        name, bio = fetch_author_bio("OL456A")
+        
+        assert name == "John Michael Doe"
+        assert bio == "Author biography."
+
+    @patch("pyopds2_openlibrary._get")
+    def test_strips_markdown_from_bio(self, mock_get):
+        """Markdown in bio is stripped to plain text."""
+        response = MagicMock()
+        response.json.return_value = {
+            "name": "Author",
+            "bio": "**Bold** and *italic* text.",
+        }
+        mock_get.return_value = response
+        
+        name, bio = fetch_author_bio("OL789A")
+        
+        assert bio == "Bold and italic text."
+
+    @patch("pyopds2_openlibrary._get")
+    def test_handles_dict_bio_value(self, mock_get):
+        """Bio can be a dict with 'value' key."""
+        response = MagicMock()
+        response.json.return_value = {
+            "name": "Author",
+            "bio": {"value": "Bio text"},
+        }
+        mock_get.return_value = response
+        
+        name, bio = fetch_author_bio("OLABCA")
+        
+        assert bio == "Bio text"
+
+    @patch("pyopds2_openlibrary._get")
+    def test_returns_none_on_error(self, mock_get):
+        """Return (None, None) if fetch fails."""
+        mock_get.side_effect = Exception("API error")
+        
+        name, bio = fetch_author_bio("OLXYZ")
+        
+        assert name is None
+        assert bio is None
+
+    @patch("pyopds2_openlibrary._get")
+    def test_prefers_latin_personal_name_over_primary_name(self, mock_get):
+        """Prefer Latin personal_name over non-Latin primary name."""
+        response = MagicMock()
+        response.json.return_value = {
+            "name": "Иван Петров",
+            "personal_name": "Ivan Petrov",
+            "bio": "Bio",
+        }
+        mock_get.return_value = response
+        
+        name, bio = fetch_author_bio("OLFDA")
+        
+        assert name == "Ivan Petrov"
+
+
+class TestStripMarkdown:
+    """Test Markdown and HTML stripping."""
+
+    def test_plain_text_unchanged(self):
+        """Plain text without Markdown should be unchanged."""
+        result = strip_markdown("This is plain text.")
+        assert result == "This is plain text."
+
+    def test_bold_text_stripped(self):
+        """Bold Markdown (**text**) should be stripped."""
+        result = strip_markdown("This is **bold** text.")
+        assert result == "This is bold text."
+
+    def test_italic_text_stripped(self):
+        """Italic Markdown (*text*) should be stripped."""
+        result = strip_markdown("This is *italic* text.")
+        assert result == "This is italic text."
+
+    def test_links_stripped(self):
+        """Markdown links [text](url) are converted to text."""
+        result = strip_markdown("Click [here](https://example.org) for more.")
+        assert "https://example.org" not in result
+        assert "here" in result
+
+    def test_headers_stripped(self):
+        """Markdown headers (# H1, ## H2) are stripped."""
+        result = strip_markdown("# Header\nSome text.")
+        assert "#" not in result
+        assert "Header" in result
+        assert "Some text" in result
+
+    def test_inline_html_stripped(self):
+        """Inline HTML is stripped."""
+        result = strip_markdown("This is <b>bold</b> text.")
+        assert "<b>" not in result
+        assert "bold" in result
+
+    def test_multiple_newlines_collapsed(self):
+        """Multiple consecutive newlines are collapsed to max 2."""
+        result = strip_markdown("Line 1\n\n\n\n\nLine 2")
+        assert "\n\n\n" not in result
+        lines = result.split("\n")
+        assert any("Line 1" in line for line in lines)
+        assert any("Line 2" in line for line in lines)
+
+    def test_result_trimmed(self):
+        """Result is stripped of leading/trailing whitespace."""
+        result = strip_markdown("  Some text  ")
+        assert result == "Some text"
+
+    def test_empty_string(self):
+        """Empty string returns empty string."""
+        result = strip_markdown("")
+        assert result == ""
+
+    def test_complex_markdown_stripped(self):
+        """Complex Markdown with multiple features."""
+        markdown = """# Title
+
+This is **bold** and *italic* text.
+
+[Link](https://example.org)
+
+- Bullet 1
+- Bullet 2
+"""
+        result = strip_markdown(markdown)
+        
+        assert "#" not in result
+        assert "Title" in result
+        assert "bold" in result
+        assert "italic" in result
+        assert "https://example.org" not in result
+        assert "Link" in result
+
+
+class TestLibriVoxSupport:
+    """Test LibriVox audio support in records."""
+
+    def test_record_with_id_librivox_has_audiobook_type(self):
+        """Record with id_librivox has Audiobook type."""
+        record = OpenLibraryDataRecord.model_validate({
+            "key": "/works/OL1W",
+            "title": "Audio Book",
+            "id_librivox": ["librivox_id_123"]
+        })
+        
+        assert record.type == "http://schema.org/Audiobook"
+
+    def test_record_without_id_librivox_has_book_type(self):
+        """Record without id_librivox has Book type."""
+        record = OpenLibraryDataRecord.model_validate({
+            "key": "/works/OL2W",
+            "title": "Regular Book"
+        })
+        
+        assert record.type == "http://schema.org/Book"
+
+    def test_librivox_fallback_link_added_when_no_audio_links(self):
+        """Fallback LibriVox link added when no audio links exist."""
+        record = OpenLibraryDataRecord.model_validate({
+            "key": "/works/OL3W",
+            "title": "Audio Book",
+            "id_librivox": ["librivox_123"],
+            "editions": {
+                "docs": [{
+                    "key": "/books/OL3M",
+                    "title": "Audio Book",
+                    "providers": []
+                }]
+            }
+        })
+        
+        links = record.links()
+        
+        librivox_links = [l for l in links if l.title == "LibriVox"]
+        assert len(librivox_links) == 1
+        assert librivox_links[0].href == "https://librivox.org/librivox_123"
+
+    def test_librivox_fallback_skipped_when_librivox_link_already_present(self):
+        """Fallback link not added when LibriVox link already exists from provider."""
+        # Create a record where the provider URL is already a librivox link
+        record = OpenLibraryDataRecord.model_validate({
+            "key": "/works/OL4W",
+            "title": "Audio Book",
+            "id_librivox": ["librivox_456"],
+            "editions": {
+                "docs": [{
+                    "key": "/books/OL4M",
+                    "title": "Audio Book",
+                    "providers": [{
+                        "url": "https://librivox.org/librivox_other",
+                        "format": "web"
+                    }]
+                }]
+            }
+        })
+        
+        links = record.links()
+        
+        # Count LibriVox links (should only have one, from the provider, not a fallback)
+        librivox_links = [l for l in links if l.href.startswith("https://librivox.org")]
+        # The provider creates one link, and the fallback checks if any librivox link exists
+        assert len(librivox_links) >= 1
+
+    def test_multiple_librivox_ids(self):
+        """Uses first ID when multiple are present."""
+        record = OpenLibraryDataRecord.model_validate({
+            "key": "/works/OL5W",
+            "title": "Audio Book",
+            "id_librivox": ["first_id", "second_id"],
+            "editions": {
+                "docs": [{
+                    "key": "/books/OL5M",
+                    "title": "Audio Book",
+                    "providers": []
+                }]
+            }
+        })
+        
+        links = record.links()
+        librivox_links = [l for l in links if l.title == "LibriVox"]
+        
+        assert librivox_links[0].href == "https://librivox.org/first_id"

--- a/tests/test_openlibrary_catalog.py
+++ b/tests/test_openlibrary_catalog.py
@@ -467,7 +467,9 @@ class TestOpenLibraryDataProvider:
             mock_response.raise_for_status.return_value = None
             mock_get.return_value = mock_response
 
-            catalog = Catalog.create(OpenLibraryDataProvider.search("any query"))
+            # Pass access="print_disabled" when testing print-disabled books
+            search_access = "print_disabled" if ebook_access == "printdisabled" else None
+            catalog = Catalog.create(OpenLibraryDataProvider.search("any query", access=search_access))
             publication = catalog.publications[0]
             acquisition_link = next((link for link in publication.links if '/acquisition/' in link.rel), None)
             return acquisition_link.properties['availability']
@@ -690,13 +692,17 @@ class TestFacetCountsAndBuilder:
     def test_build_facets_groups_and_links_and_rels(self):
         facets = build_facets(base_url="https://example.org/opds", query="fox", sort="new", mode="ebooks")
 
-        assert len(facets) == 3
+        assert len(facets) == 4
         assert facets[0]["metadata"]["title"] == "Availability"
         assert facets[1]["metadata"]["title"] == "Language"
         assert facets[2]["metadata"]["title"] == "Media Type"
+        assert facets[3]["metadata"]["title"] == "Access"
 
         availability_titles = [l["title"] for l in facets[0]["links"]]
-        assert availability_titles == ["Everything", "Available to Borrow", "Print Disabled", "Open Access", "Available for Purchase"]
+        assert availability_titles == ["Everything", "Available to Borrow", "Open Access", "Available for Purchase"]
+
+        access_titles = [l["title"] for l in facets[3]["links"]]
+        assert access_titles == ["General", "Print Disabled"]
 
         for link in facets[0]["links"]:
             assert link["type"] == "application/opds+json"
@@ -710,6 +716,12 @@ class TestFacetCountsAndBuilder:
         parsed = parse_qs(urlparse(everything["href"]).query)
         assert parsed.get("query") == ["fox"]
         assert parsed.get("language") is None
+
+        # Check Access facet
+        for link in facets[3]["links"]:
+            assert link["type"] == "application/opds+json"
+            assert "title" in link
+            assert "href" in link
 
     def test_build_facets_media_type_links(self):
         facets = build_facets(
@@ -813,21 +825,21 @@ class TestSearchModeHandling:
             self._solr_doc(
                 key="/works/OLP1W",
                 title="Paid Available",
-                ebook_access="printdisabled",
+                ebook_access="borrowable",
                 availability_status="borrow_available",
                 providers=[{"price": "9.99 USD", "access": "borrow", "format": "epub", "url": "https://x/1"}],
             ),
             self._solr_doc(
                 key="/works/OLF1W",
                 title="Free Unavailable",
-                ebook_access="printdisabled",
+                ebook_access="borrowable",
                 availability_status="borrow_unavailable",
                 providers=[{"price": "0.00 USD", "access": "borrow", "format": "epub", "url": "https://x/2"}],
             ),
             self._solr_doc(
                 key="/works/OLN1W",
                 title="No Providers",
-                ebook_access="printdisabled",
+                ebook_access="borrowable",
                 availability_status="borrow_available",
                 providers=[],
             ),
@@ -919,7 +931,7 @@ class TestSearchAcquisitionFilterAllModes:
             "title": title,
             "cover_i": 123,
             "description": description,
-            "ebook_access": "printdisabled",
+            "ebook_access": "public",
             "editions": {
                 "docs": [
                     {
@@ -1150,7 +1162,7 @@ class TestSearchTotalsByMode:
                 "key": "/works/OL51W",
                 "title": "Paid",
                 "cover_i": 123,
-                "ebook_access": "printdisabled",
+                "ebook_access": "public",
                 "editions": {
                     "docs": [
                         {
@@ -1167,7 +1179,7 @@ class TestSearchTotalsByMode:
                 "key": "/works/OL52W",
                 "title": "Free",
                 "cover_i": 123,
-                "ebook_access": "printdisabled",
+                "ebook_access": "public",
                 "editions": {
                     "docs": [
                         {

--- a/tests/test_openlibrary_comprehensive.py
+++ b/tests/test_openlibrary_comprehensive.py
@@ -20,13 +20,17 @@ from pyopds2_openlibrary import (
     _has_acquisition_options,
     _has_buyable_provider,
     _is_currently_available,
+    _is_latin_name,
+    _latin_name_for_author,
     _parse_price_amount,
     _resolve_preferred_edition,
+    fetch_author_bio,
     fetch_languages_map,
     iso_639_1_to_marc,
     map_ol_format_to_mime,
     marc_language_to_iso_639_1,
     ol_acquisition_to_opds_links,
+    strip_markdown,
 )
 
 build_facets = OpenLibraryDataProvider.build_facets
@@ -934,7 +938,7 @@ class TestResolvePreferredEdition:
                                 "key": "/books/OLFRA",
                                 "title": "French",
                                 "language": ["fr"],
-                                "providers": [{"url": "https://fr.example", "format": "epub"}],
+                                "ebook_access": "public",
                             }
                         ]
                     },
@@ -973,7 +977,7 @@ class TestResolvePreferredEdition:
 class TestAvailabilityFacetPrimitive:
     def test_all_modes_included_by_default(self):
         links = _build_availability_links(mode="everything", href_fn=lambda m: f"/search?mode={m}")
-        assert [l["title"] for l in links] == ["Everything", "Available to Borrow", "Print Disabled", "Open Access", "Available for Purchase"]
+        assert [l["title"] for l in links] == ["Everything", "Available to Borrow", "Open Access", "Available for Purchase"]
 
     def test_active_mode_gets_self_rel(self):
         links = _build_availability_links(mode="ebooks", href_fn=lambda m: f"/search?mode={m}")
@@ -1009,22 +1013,27 @@ class TestAvailabilityFacetPrimitive:
             href_fn=lambda m: f"/search?mode={m}",
             exclude={"buyable"},
         )
-        assert len(links) == 4
+        assert len(links) == 3
         assert all(l["title"] != "Available for Purchase" for l in links)
 
 
 class TestFacetBuilders:
     def test_build_facets_returns_availability_group(self):
         facets = build_facets(base_url="https://example.org/opds", query="cats")
-        assert len(facets) == 3
+        assert len(facets) == 4
         assert facets[0]["metadata"]["title"] == "Availability"
         assert facets[1]["metadata"]["title"] == "Language"
         assert facets[2]["metadata"]["title"] == "Media Type"
+        assert facets[3]["metadata"]["title"] == "Access"
 
     def test_build_facets_availability_links_titles(self):
         facets = build_facets(base_url="https://example.org/opds", query="cats")
         titles = [l["title"] for l in facets[0]["links"]]
-        assert titles == ["Everything", "Available to Borrow", "Print Disabled", "Open Access", "Available for Purchase"]
+        assert titles == ["Everything", "Available to Borrow", "Open Access", "Available for Purchase"]
+        
+        # Check Access facet exists and has correct links
+        access_titles = [l["title"] for l in facets[3]["links"]]
+        assert access_titles == ["General", "Print Disabled"]
 
     def test_build_facets_media_type_links_titles(self):
         facets = build_facets(base_url="https://example.org/opds", query="cats", media_type="ebook")
@@ -1066,18 +1075,19 @@ class TestFacetBuilders:
 
     def test_build_home_facets_returns_availability_only(self):
         facets = OpenLibraryDataProvider.build_home_facets(base_url="https://example.org/opds", mode="everything")
-        assert len(facets) == 3
+        assert len(facets) == 4
         assert facets[0]["metadata"]["title"] == "Availability"
         assert facets[1]["metadata"]["title"] == "Language"
         assert facets[2]["metadata"]["title"] == "Media Type"
+        assert facets[3]["metadata"]["title"] == "Access"
 
     def test_build_home_facets_uses_home_labels(self):
         facets = OpenLibraryDataProvider.build_home_facets(base_url="https://example.org/opds", mode="everything")
-        assert [l["title"] for l in facets[0]["links"]] == ["Everything", "Available to Borrow", "Print Disabled", "Open Access"]
+        assert [l["title"] for l in facets[0]["links"]] == ["Everything", "Available to Borrow", "Open Access"]
 
     def test_build_home_facets_excludes_buyable(self):
         facets = OpenLibraryDataProvider.build_home_facets(base_url="https://example.org/opds", mode="everything")
-        assert len(facets[0]["links"]) == 4
+        assert len(facets[0]["links"]) == 3
 
     def test_build_home_facets_links_point_to_root_mode(self):
         facets = OpenLibraryDataProvider.build_home_facets(base_url="https://example.org/opds", mode="ebooks")
@@ -1138,7 +1148,7 @@ class TestHomeFeed:
         assert "previous" not in links_by_rel
 
         assert len(feed["groups"]) == OpenLibraryDataProvider.GROUPS_PER_PAGE
-        assert len(feed["facets"]) == 3
+        assert len(feed["facets"]) == 4
         assert len(feed["navigation"]) == 2
 
         first_nav_qs = parse_qs(urlparse(feed["navigation"][0].href).query)
@@ -1184,7 +1194,7 @@ class TestHomeFeed:
         assert links_by_rel["next"].href == "https://example.org/opds/?page=3"
         assert links_by_rel["previous"].href == "https://example.org/opds/"
         assert feed["navigation"] == []
-        assert len(feed["facets"]) == 3
+        assert len(feed["facets"]) == 4
 
     @patch("pyopds2_openlibrary.OpenLibraryDataProvider.search")
     @patch("pyopds2_openlibrary.Catalog")
@@ -1270,7 +1280,7 @@ class TestSearch:
         title: str,
         price: str | None,
         status: str,
-        ebook_access: str = "printdisabled",
+        ebook_access: str = "public",
         providers: list[dict] | None = None,
         editions_docs: list[dict] | None = None,
     ) -> dict:
@@ -1382,7 +1392,7 @@ class TestSearch:
                     "key": "/works/OL2W",
                     "title": "Ebook",
                     "cover_i": 123,
-                    "ebook_access": "printdisabled",
+                    "ebook_access": "public",
                     "editions": {
                         "docs": [
                             {
@@ -1468,14 +1478,14 @@ class TestSearch:
     @pytest.mark.parametrize("mode", ["ebooks", "buyable"])
     @patch("pyopds2_openlibrary.httpx.get")
     def test_available_books_sorted_before_unavailable(self, mock_get, mode: str):
-        ebook_access = "public" if mode == "open_access" else "printdisabled"
+        # Use "public" ebook_access for ebooks/buyable modes (these are about filtering availability, not print-disabled)
         response = MagicMock()
         response.raise_for_status.return_value = None
         response.json.return_value = {
             "numFound": 2,
             "docs": [
-                self._search_doc("/works/OL1W", "Unavailable", "9.99 USD", "borrow_unavailable", ebook_access=ebook_access),
-                self._search_doc("/works/OL2W", "Available", "9.99 USD", "borrow_available", ebook_access=ebook_access),
+                self._search_doc("/works/OL1W", "Unavailable", "9.99 USD", "borrow_unavailable", ebook_access="borrowable"),
+                self._search_doc("/works/OL2W", "Available", "9.99 USD", "borrow_available", ebook_access="borrowable"),
             ],
         }
         mock_get.return_value = response


### PR DESCRIPTION
Closes #73 #75 #76 
This pull request introduces a new "Access" facet to the OPDS 2.0 API, allowing users to filter between general content and print-disabled content across search, homepage, and author catalog endpoints. It also improves the handling of descriptions for homepage groups and refines the filtering logic for print-disabled books. The most important changes are grouped below:

### Access Facet and Filtering

* Added an "Access" facet group (with "General" and "Print Disabled" options) to search, homepage, and author catalog endpoints, including new `_ACCESS_OPTIONS`, `_build_access_links`, and corresponding UI links. [[1]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113R950-R981) [[2]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113R1224-R1230) [[3]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113R1326-R1332) [[4]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113R1263-R1264) [[5]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113R1275-R1276) [[6]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113R1287-R1300) [[7]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113R1356) [[8]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113R1369-R1370) [[9]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113R1396-R1402) [[10]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113R1485) [[11]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113R1495-R1496) [[12]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113R1510) [[13]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113L1446-R1555)
* Updated all relevant endpoint methods (`build_facets`, `build_home_facets`, `build_author_facets`, `build_home_feed`, etc.) and their internal link builders to support and propagate the new `access` parameter. [[1]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113R1142) [[2]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113R1239) [[3]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113R1344) [[4]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113R1634)
* Refined the search logic to filter records according to the selected access option: "general" hides print-disabled content, while "print_disabled" shows only print-disabled books. [[1]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113L1643-R1770) [[2]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113L1658-R1779)

### Homepage Group Improvements

* Added descriptions for homepage groups such as "Standard Ebooks", "Classic Books", and "Kids", and included these in the homepage group metadata. [[1]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113R1024-R1040) [[2]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113L1446-R1555)

### Minor Improvements & Refactoring

* Fixed and clarified the handling of descriptions in metadata, ensuring English descriptions are preferred when available.
* Cleaned up availability mode definitions and query construction for print-disabled content. [[1]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113L811) [[2]](diffhunk://#diff-051b7550fc7fb3a378f8bdefbc369d02a42faf4987ae7470fc2bc8791baa8113L1025-R1082)

These changes provide more granular control over content accessibility and improve the clarity and usability of the OPDS feeds.