### PR TITLE
Filter out machine tags from subjects in OpenLibraryDataRecord for improved readability

### DIFF
--- a/pyopds2_openlibrary/__init__.py
+++ b/pyopds2_openlibrary/__init__.py
@@ -328,14 +328,18 @@ class OpenLibraryDataRecord(BookSharedDoc, DataProviderRecord):
         # objects whose link browses the app's /search by subject name. Embedded
         # double-quotes are stripped so the Solr quoted clause can't break; the
         # name keeps its original text. Omit entirely for works with no subjects.
+        # Colon-separated subjects (e.g. ``content_warning:cover``) are machine
+        # tags, not human-readable, so they are filtered out before slicing.
         subjects = None
         if self.subject:
             opds_base = OpenLibraryDataProvider.OPDS_BASE_URL or f"{OpenLibraryDataProvider.BASE_URL}/opds"
             subjects = []
-            for name in self.subject[:10]:
+            human_readable = [name for name in self.subject if ":" not in name]
+            for name in human_readable[:10]:
                 query = f'subject:"{name.replace(chr(34), "")}"'
                 href = f"{opds_base}/search?" + urlencode({"query": query, "title": name})
                 subjects.append(Subject(name=name, links=[Link(type="application/opds+json", href=href)]))
+            subjects = subjects or None
 
         return Metadata(
             type=self.type,

--- a/tests/test_openlibrary_catalog.py
+++ b/tests/test_openlibrary_catalog.py
@@ -16,6 +16,7 @@ from pyopds2_openlibrary import (
     _resolve_preferred_edition,
     fetch_languages_map,
     ol_acquisition_to_opds_links,
+    Subject,
 )
 
 build_facets = OpenLibraryDataProvider.build_facets
@@ -194,6 +195,22 @@ class TestOpenLibraryDataRecord:
         assert len(metadata.author) == 1
         assert metadata.author[0].name == "Test Author"
         assert metadata.numberOfPages == 200
+
+    def test_subjects_filter_out_machine_tags(self):
+        """Subjects containing machine tags (colon-separated) are filtered out."""
+        record = OpenLibraryDataRecord(
+            key="/works/OLSUB1W",
+            title="Subject Test",
+            subject=["Fiction", "content_warning:cover", "genre:fiction"]
+        )
+
+        metadata = record.metadata()
+
+        assert metadata.subject is not None
+        # Names should not contain machine-tag colons
+        names = [s.name if isinstance(s, Subject) else s for s in metadata.subject]
+        assert "Fiction" in names
+        assert all(":" not in name for name in names)
 
     def test_record_links(self):
         """Test link generation from a record."""


### PR DESCRIPTION
Closes #91 
This pull request updates the way subjects are handled in the `get_authors` function to ensure only human-readable subjects are included. Specifically, it filters out machine tags (subjects containing a colon) before generating subject links.

**Subject handling improvements:**

* Filters out colon-separated subjects (machine tags) from the `self.subject` list before slicing and generating OPDS subject links, ensuring only human-readable subjects are included.
* Ensures that the `subjects` variable is set to `None` if no human-readable subjects remain after filtering.
