### PR TITLE
perf: introduce httpx.Client singleton to reuse TLS connections (#99)

### DIFF
--- a/pyopds2_openlibrary/__init__.py
+++ b/pyopds2_openlibrary/__init__.py
@@ -1,4 +1,5 @@
 import re as _re
+import threading as _threading
 import time as _time
 import typing
 import unicodedata as _unicodedata
@@ -100,6 +101,32 @@ def _user_agent() -> str:
     return ua or DEFAULT_USER_AGENT
 
 
+_http_client: "httpx.Client | None" = None
+_http_client_lock = _threading.Lock()
+
+
+def _get_http_client() -> "httpx.Client":
+    """Return the shared httpx.Client singleton (thread-safe, lazy init)."""
+    global _http_client
+    if _http_client is None:
+        with _http_client_lock:
+            if _http_client is None:
+                _http_client = httpx.Client(
+                    limits=httpx.Limits(
+                        max_keepalive_connections=10,
+                        max_connections=20,
+                        keepalive_expiry=30.0,
+                    ),
+                    timeout=httpx.Timeout(
+                        connect=5.0,
+                        read=_REQUEST_TIMEOUT,
+                        write=5.0,
+                        pool=2.0,
+                    ),
+                )
+    return _http_client
+
+
 def _get(url: str, *, params=None, timeout: float = _REQUEST_TIMEOUT) -> httpx.Response:
     """``httpx.get`` with automatic retry on transient HTTP/network errors.
 
@@ -115,7 +142,7 @@ def _get(url: str, *, params=None, timeout: float = _REQUEST_TIMEOUT) -> httpx.R
         if delay:
             _time.sleep(delay)
         try:
-            r = httpx.get(url, params=params, timeout=timeout, headers={"User-Agent": _user_agent()})
+            r = _get_http_client().get(url, params=params, timeout=timeout, headers={"User-Agent": _user_agent()})
             is_last = i == len(delays) - 1
             if r.status_code in _RETRY_STATUS_CODES and not is_last:
                 # Honour Retry-After on 429; overwrite the *next* scheduled delay.

--- a/pyopds2_openlibrary/__init__.py
+++ b/pyopds2_openlibrary/__init__.py
@@ -1,3 +1,4 @@
+import atexit as _atexit
 import re as _re
 import threading as _threading
 import time as _time
@@ -101,11 +102,11 @@ def _user_agent() -> str:
     return ua or DEFAULT_USER_AGENT
 
 
-_http_client: "httpx.Client | None" = None
+_http_client: Optional[httpx.Client] = None
 _http_client_lock = _threading.Lock()
 
 
-def _get_http_client() -> "httpx.Client":
+def _get_http_client() -> httpx.Client:
     """Return the shared httpx.Client singleton (thread-safe, lazy init)."""
     global _http_client
     if _http_client is None:
@@ -124,6 +125,7 @@ def _get_http_client() -> "httpx.Client":
                         pool=2.0,
                     ),
                 )
+                _atexit.register(_http_client.close)
     return _http_client
 
 
@@ -142,7 +144,12 @@ def _get(url: str, *, params=None, timeout: float = _REQUEST_TIMEOUT) -> httpx.R
         if delay:
             _time.sleep(delay)
         try:
-            r = _get_http_client().get(url, params=params, timeout=timeout, headers={"User-Agent": _user_agent()})
+            r = _get_http_client().get(
+                url,
+                params=params,
+                timeout=httpx.Timeout(connect=5.0, read=timeout, write=5.0, pool=2.0),
+                headers={"User-Agent": _user_agent()},
+            )
             is_last = i == len(delays) - 1
             if r.status_code in _RETRY_STATUS_CODES and not is_last:
                 # Honour Retry-After on 429; overwrite the *next* scheduled delay.

--- a/tests/test_new_changes.py
+++ b/tests/test_new_changes.py
@@ -4,18 +4,20 @@ import pyopds2_openlibrary as openlibrary
 from pyopds2_openlibrary import OpenLibraryDataProvider
 
 
-@patch("pyopds2_openlibrary.httpx.get")
-def test_count_for_mode_print_disabled_appends_filter(mock_get):
+@patch("pyopds2_openlibrary._get_http_client")
+def test_count_for_mode_print_disabled_appends_filter(mock_get_client):
+    mock_client = MagicMock()
+    mock_get_client.return_value = mock_client
     resp = MagicMock()
     resp.raise_for_status.return_value = None
     resp.json.return_value = {"numFound": 7}
-    mock_get.return_value = resp
+    mock_client.get.return_value = resp
 
     # Call internal helper for print_disabled mode
     total = OpenLibraryDataProvider._count_for_mode("cats", "print_disabled")
 
     # Verify HTTP call used the printdisabled ebook_access filter
-    called_params = mock_get.call_args.kwargs["params"]
+    called_params = mock_client.get.call_args.kwargs["params"]
     assert "q" in called_params
     assert "ebook_access:printdisabled" in called_params["q"]
     assert called_params["limit"] == 0

--- a/tests/test_openlibrary_catalog.py
+++ b/tests/test_openlibrary_catalog.py
@@ -32,12 +32,14 @@ class TestOpenLibraryCatalogCreation:
     """Test catalog creation using OpenLibraryDataProvider."""
 
     @patch('pyopds2_openlibrary.fetch_languages_map')
-    @patch('pyopds2_openlibrary.httpx.get')
-    def test_create_catalog_from_search(self, mock_get, mock_lang_map):
+    @patch('pyopds2_openlibrary._get_http_client')
+    def test_create_catalog_from_search(self, mock_get_client, mock_lang_map):
         """Test creating a catalog from search results."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
         # Mock the language map
         mock_lang_map.return_value = {"eng": "en"}
-        
+
         # Mock the search API response
         mock_response = MagicMock()
         mock_response.json.return_value = {
@@ -79,7 +81,7 @@ class TestOpenLibraryCatalogCreation:
             ]
         }
         mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
+        mock_client.get.return_value = mock_response
 
         # Create catalog from search
         catalog = Catalog.create(OpenLibraryDataProvider.search("roald dahl", limit=10))
@@ -107,9 +109,11 @@ class TestOpenLibraryCatalogCreation:
         assert first_pub.links is not None
         assert len(first_pub.links) > 0
 
-    @patch('pyopds2_openlibrary.httpx.get')
-    def test_search_with_pagination(self, mock_get):
+    @patch('pyopds2_openlibrary._get_http_client')
+    def test_search_with_pagination(self, mock_get_client):
         """Test search with pagination parameters."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
         mock_response = MagicMock()
         mock_response.json.return_value = {
             "numFound": 100,
@@ -134,7 +138,7 @@ class TestOpenLibraryCatalogCreation:
             ]
         }
         mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
+        mock_client.get.return_value = mock_response
 
         # Perform search with pagination
         result = OpenLibraryDataProvider.search("test", limit=10, offset=20)
@@ -147,16 +151,18 @@ class TestOpenLibraryCatalogCreation:
         assert result.offset == 20
         assert len(result.records) == 1
 
-    @patch('pyopds2_openlibrary.httpx.get')
-    def test_empty_search_results(self, mock_get):
+    @patch('pyopds2_openlibrary._get_http_client')
+    def test_empty_search_results(self, mock_get_client):
         """Test catalog creation with empty search results."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
         mock_response = MagicMock()
         mock_response.json.return_value = {
             "numFound": 0,
             "docs": []
         }
         mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
+        mock_client.get.return_value = mock_response
 
         # Create catalog with empty results
         catalog = Catalog.create(OpenLibraryDataProvider.search("nonexistent"))
@@ -390,9 +396,11 @@ class TestOpenLibraryDataProvider:
         assert OpenLibraryDataProvider.TITLE == "OpenLibrary.org OPDS Service"
         assert OpenLibraryDataProvider.SEARCH_URL == "/opds/search{?query}"
 
-    @patch('pyopds2_openlibrary.httpx.get')
-    def test_search_method(self, mock_get):
+    @patch('pyopds2_openlibrary._get_http_client')
+    def test_search_method(self, mock_get_client):
         """Test the search method directly."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
         mock_response = MagicMock()
         mock_response.json.return_value = {
             "numFound": 1,
@@ -415,7 +423,7 @@ class TestOpenLibraryDataProvider:
             ]
         }
         mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
+        mock_client.get.return_value = mock_response
 
         result = OpenLibraryDataProvider.search("test query")
 
@@ -424,29 +432,33 @@ class TestOpenLibraryDataProvider:
         assert result.query == "test query"
         assert len(result.records) == 1
 
-    @patch('pyopds2_openlibrary.httpx.get')
-    def test_search_with_sort(self, mock_get):
+    @patch('pyopds2_openlibrary._get_http_client')
+    def test_search_with_sort(self, mock_get_client):
         """Test search with sort parameter."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
         mock_response = MagicMock()
         mock_response.json.return_value = {
             "numFound": 1,
             "docs": [{"key": "/works/OL45804W", "title": "Test"}]
         }
         mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
+        mock_client.get.return_value = mock_response
 
         result = OpenLibraryDataProvider.search("test", sort="rating")
 
         assert result.sort == "rating"
         # Verify sort was passed in the request
-        mock_get.assert_called_once()
-        call_args = mock_get.call_args
+        mock_client.get.assert_called_once()
+        call_args = mock_client.get.call_args
         assert call_args[1]['params']['sort'] == "rating"
 
     @patch('pyopds2_openlibrary.fetch_languages_map')
-    @patch('pyopds2_openlibrary.httpx.get')
-    def test_availability(self, mock_get, mock_lang_map):
+    @patch('pyopds2_openlibrary._get_http_client')
+    def test_availability(self, mock_get_client, mock_lang_map):
         """Availability is computed correctly without making real API calls."""
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
         mock_lang_map.return_value = {"eng": "en"}
 
         def get_availability(ebook_access, availability_status):
@@ -482,7 +494,7 @@ class TestOpenLibraryDataProvider:
                 ],
             }
             mock_response.raise_for_status.return_value = None
-            mock_get.return_value = mock_response
+            mock_client.get.return_value = mock_response
 
             # Pass access="print_disabled" when testing print-disabled books
             search_access = "print_disabled" if ebook_access == "printdisabled" else None
@@ -636,56 +648,66 @@ class TestPriceAndBuyableHelpers:
 
 
 class TestFacetCountsAndBuilder:
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_count_for_mode_buyable_returns_none(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_count_for_mode_buyable_returns_none(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
         assert OpenLibraryDataProvider._count_for_mode("cats", "buyable") is None
-        mock_get.assert_not_called()
+        mock_client.get.assert_not_called()
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_count_for_mode_everything_uses_unmodified_query(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_count_for_mode_everything_uses_unmodified_query(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
         mock_response = MagicMock()
         mock_response.json.return_value = {"numFound": 7}
         mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
+        mock_client.get.return_value = mock_response
 
         total = OpenLibraryDataProvider._count_for_mode("cats", "everything")
         assert total == 7
-        q = mock_get.call_args[1]["params"]["q"]
+        q = mock_client.get.call_args[1]["params"]["q"]
         assert "cats" in q
         assert "ebook_access" in q
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_count_for_mode_ebooks_appends_filter(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_count_for_mode_ebooks_appends_filter(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
         mock_response = MagicMock()
         mock_response.json.return_value = {"numFound": 8}
         mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
+        mock_client.get.return_value = mock_response
 
         OpenLibraryDataProvider._count_for_mode("cats", "ebooks")
-        q = mock_get.call_args[1]["params"]["q"]
+        q = mock_client.get.call_args[1]["params"]["q"]
         assert "printdisabled" in q
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_count_for_mode_open_access_appends_filter(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_count_for_mode_open_access_appends_filter(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
         mock_response = MagicMock()
         mock_response.json.return_value = {"numFound": 9}
         mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
+        mock_client.get.return_value = mock_response
 
         OpenLibraryDataProvider._count_for_mode("cats", "open_access")
-        q = mock_get.call_args[1]["params"]["q"]
+        q = mock_client.get.call_args[1]["params"]["q"]
         assert "public" in q
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_count_for_mode_does_not_append_if_ebook_access_already_present(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_count_for_mode_does_not_append_if_ebook_access_already_present(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
         mock_response = MagicMock()
         mock_response.json.return_value = {"numFound": 10}
         mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
+        mock_client.get.return_value = mock_response
 
         existing = "cats ebook_access:public"
         OpenLibraryDataProvider._count_for_mode(existing, "ebooks")
-        q = mock_get.call_args[1]["params"]["q"]
+        q = mock_client.get.call_args[1]["params"]["q"]
         assert "ebook_access" in q
 
     @patch("pyopds2_openlibrary.OpenLibraryDataProvider._count_for_mode")
@@ -842,7 +864,7 @@ class TestSearchModeHandling:
             },
         }
 
-    def _mock_search_response(self, mock_get):
+    def _mock_search_response(self, mock_client):
         docs = [
             self._solr_doc(
                 key="/works/OLP1W",
@@ -869,79 +891,97 @@ class TestSearchModeHandling:
         mock_response = MagicMock()
         mock_response.json.return_value = {"numFound": 99, "docs": docs}
         mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
+        mock_client.get.return_value = mock_response
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_search_default_query_unmodified(self, mock_get):
-        self._mock_search_response(mock_get)
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_search_default_query_unmodified(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        self._mock_search_response(mock_client)
 
         OpenLibraryDataProvider.search("cats")
-        q = mock_get.call_args[1]["params"]["q"]
+        q = mock_client.get.call_args[1]["params"]["q"]
         assert "cats" in q
         assert "ebook_access" in q
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_search_everything_query_unmodified(self, mock_get):
-        self._mock_search_response(mock_get)
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_search_everything_query_unmodified(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        self._mock_search_response(mock_client)
 
         OpenLibraryDataProvider.search("cats", facets={"mode": "everything"})
-        q = mock_get.call_args[1]["params"]["q"]
+        q = mock_client.get.call_args[1]["params"]["q"]
         assert "cats" in q
         assert "ebook_access" in q
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_search_ebooks_appends_filter(self, mock_get):
-        self._mock_search_response(mock_get)
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_search_ebooks_appends_filter(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        self._mock_search_response(mock_client)
 
         OpenLibraryDataProvider.search("cats", facets={"mode": "ebooks"})
-        q = mock_get.call_args[1]["params"]["q"]
+        q = mock_client.get.call_args[1]["params"]["q"]
         assert "printdisabled" in q
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_search_open_access_appends_filter(self, mock_get):
-        self._mock_search_response(mock_get)
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_search_open_access_appends_filter(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        self._mock_search_response(mock_client)
 
         OpenLibraryDataProvider.search("cats", facets={"mode": "open_access"})
-        q = mock_get.call_args[1]["params"]["q"]
+        q = mock_client.get.call_args[1]["params"]["q"]
         assert "public" in q
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_search_buyable_appends_ebooks_filter_with_guard(self, mock_get):
-        self._mock_search_response(mock_get)
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_search_buyable_appends_ebooks_filter_with_guard(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        self._mock_search_response(mock_client)
 
         OpenLibraryDataProvider.search("cats", facets={"mode": "buyable"})
-        q = mock_get.call_args[1]["params"]["q"]
+        q = mock_client.get.call_args[1]["params"]["q"]
         assert "printdisabled" in q
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_search_buyable_does_not_duplicate_existing_ebook_access_clause(self, mock_get):
-        self._mock_search_response(mock_get)
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_search_buyable_does_not_duplicate_existing_ebook_access_clause(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        self._mock_search_response(mock_client)
         query = "cats ebook_access:[printdisabled TO *]"
 
         OpenLibraryDataProvider.search(query, facets={"mode": "buyable"})
-        q = mock_get.call_args[1]["params"]["q"]
+        q = mock_client.get.call_args[1]["params"]["q"]
         assert "ebook_access" in q
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_search_buyable_filters_records_and_total(self, mock_get):
-        self._mock_search_response(mock_get)
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_search_buyable_filters_records_and_total(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        self._mock_search_response(mock_client)
 
         result = OpenLibraryDataProvider.search("cats", facets={"mode": "buyable"})
         assert result.total == 1
         assert len(result.records) == 1
         assert all(_has_buyable_provider(r) for r in result.records)
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_search_ebooks_removes_records_without_acquisition_options(self, mock_get):
-        self._mock_search_response(mock_get)
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_search_ebooks_removes_records_without_acquisition_options(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        self._mock_search_response(mock_client)
 
         result = OpenLibraryDataProvider.search("cats", facets={"mode": "ebooks"})
         assert len(result.records) == 2
         assert all(r.editions and r.editions.docs and r.editions.docs[0].providers for r in result.records)
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_filtered_modes_sort_available_before_unavailable(self, mock_get):
-        self._mock_search_response(mock_get)
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_filtered_modes_sort_available_before_unavailable(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        self._mock_search_response(mock_client)
 
         result = OpenLibraryDataProvider.search("cats", facets={"mode": "ebooks"})
         assert result.records[0].title == "Paid Available"
@@ -974,7 +1014,7 @@ class TestSearchAcquisitionFilterAllModes:
             },
         }
 
-    def _mock_response_with_mixed_acquisition(self, mock_get):
+    def _mock_response_with_mixed_acquisition(self, mock_client):
         docs = [
             self._doc_with_providers(
                 key="/works/OL31W",
@@ -1001,51 +1041,63 @@ class TestSearchAcquisitionFilterAllModes:
         mock_response = MagicMock()
         mock_response.json.return_value = {"numFound": 44, "docs": docs}
         mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
+        mock_client.get.return_value = mock_response
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_mode_everything_excludes_record_with_empty_providers(self, mock_get):
-        self._mock_response_with_mixed_acquisition(mock_get)
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_mode_everything_excludes_record_with_empty_providers(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        self._mock_response_with_mixed_acquisition(mock_client)
 
         result = OpenLibraryDataProvider.search("cats", facets={"mode": "everything"})
         titles = [r.title for r in result.records]
         assert "No providers" not in titles
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_mode_everything_excludes_record_with_all_null_provider_urls(self, mock_get):
-        self._mock_response_with_mixed_acquisition(mock_get)
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_mode_everything_excludes_record_with_all_null_provider_urls(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        self._mock_response_with_mixed_acquisition(mock_client)
 
         result = OpenLibraryDataProvider.search("cats", facets={"mode": "everything"})
         titles = [r.title for r in result.records]
         assert "Null urls only" not in titles
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_mode_everything_keeps_record_with_valid_provider_url(self, mock_get):
-        self._mock_response_with_mixed_acquisition(mock_get)
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_mode_everything_keeps_record_with_valid_provider_url(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        self._mock_response_with_mixed_acquisition(mock_client)
 
         result = OpenLibraryDataProvider.search("cats", facets={"mode": "everything"})
         titles = [r.title for r in result.records]
         assert "Valid provider" in titles
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_mode_everything_excludes_described_record_without_providers(self, mock_get):
-        self._mock_response_with_mixed_acquisition(mock_get)
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_mode_everything_excludes_described_record_without_providers(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        self._mock_response_with_mixed_acquisition(mock_client)
 
         result = OpenLibraryDataProvider.search("cats", facets={"mode": "everything"})
         titles = [r.title for r in result.records]
         assert "Has description only" not in titles
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_mode_ebooks_excludes_record_without_providers(self, mock_get):
-        self._mock_response_with_mixed_acquisition(mock_get)
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_mode_ebooks_excludes_record_without_providers(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        self._mock_response_with_mixed_acquisition(mock_client)
 
         result = OpenLibraryDataProvider.search("cats", facets={"mode": "ebooks"})
         titles = [r.title for r in result.records]
         assert "No providers" not in titles
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_mode_open_access_excludes_record_without_providers(self, mock_get):
-        self._mock_response_with_mixed_acquisition(mock_get)
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_mode_open_access_excludes_record_without_providers(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        self._mock_response_with_mixed_acquisition(mock_client)
 
         result = OpenLibraryDataProvider.search("cats", facets={"mode": "open_access"})
         titles = [r.title for r in result.records]
@@ -1053,21 +1105,25 @@ class TestSearchAcquisitionFilterAllModes:
 
 
 class TestRequestTimeoutUsage:
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_fetch_languages_map_passes_timeout(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_fetch_languages_map_passes_timeout(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
         _reset_languages_map_cache()
         mock_response = MagicMock()
         mock_response.json.return_value = []
         mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
+        mock_client.get.return_value = mock_response
 
         fetch_languages_map()
 
-        assert mock_get.call_args[1]["timeout"] == 30.0
-        assert mock_get.call_args[1]["timeout"] == _REQUEST_TIMEOUT
+        assert mock_client.get.call_args[1]["timeout"] == 30.0
+        assert mock_client.get.call_args[1]["timeout"] == _REQUEST_TIMEOUT
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_resolve_preferred_edition_editions_request_passes_timeout(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_resolve_preferred_edition_editions_request_passes_timeout(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
         first_response = MagicMock()
         first_response.raise_for_status.return_value = None
         first_response.json.return_value = {
@@ -1096,15 +1152,17 @@ class TestRequestTimeoutUsage:
                 }
             ]
         }
-        mock_get.side_effect = [first_response, second_response]
+        mock_client.get.side_effect = [first_response, second_response]
 
         _resolve_preferred_edition("/works/OL40W", "eng", ["key", "title", "providers"])
 
-        assert mock_get.call_args_list[0].kwargs["timeout"] == 30.0
-        assert mock_get.call_args_list[0].kwargs["timeout"] == _REQUEST_TIMEOUT
+        assert mock_client.get.call_args_list[0].kwargs["timeout"] == 30.0
+        assert mock_client.get.call_args_list[0].kwargs["timeout"] == _REQUEST_TIMEOUT
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_resolve_preferred_edition_search_request_passes_timeout(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_resolve_preferred_edition_search_request_passes_timeout(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
         first_response = MagicMock()
         first_response.raise_for_status.return_value = None
         first_response.json.return_value = {
@@ -1133,27 +1191,31 @@ class TestRequestTimeoutUsage:
                 }
             ]
         }
-        mock_get.side_effect = [first_response, second_response]
+        mock_client.get.side_effect = [first_response, second_response]
 
         _resolve_preferred_edition("/works/OL41W", "eng", ["key", "title", "providers"])
 
-        assert mock_get.call_args_list[1].kwargs["timeout"] == 30.0
-        assert mock_get.call_args_list[1].kwargs["timeout"] == _REQUEST_TIMEOUT
+        assert mock_client.get.call_args_list[1].kwargs["timeout"] == 30.0
+        assert mock_client.get.call_args_list[1].kwargs["timeout"] == _REQUEST_TIMEOUT
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_count_for_mode_passes_timeout(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_count_for_mode_passes_timeout(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
         mock_response = MagicMock()
         mock_response.json.return_value = {"numFound": 1}
         mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
+        mock_client.get.return_value = mock_response
 
         OpenLibraryDataProvider._count_for_mode("cats", "everything")
 
-        assert mock_get.call_args[1]["timeout"] == 30.0
-        assert mock_get.call_args[1]["timeout"] == _REQUEST_TIMEOUT
+        assert mock_client.get.call_args[1]["timeout"] == 30.0
+        assert mock_client.get.call_args[1]["timeout"] == _REQUEST_TIMEOUT
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_search_passes_timeout(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_search_passes_timeout(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
         mock_response = MagicMock()
         mock_response.json.return_value = {
             "numFound": 1,
@@ -1176,12 +1238,12 @@ class TestRequestTimeoutUsage:
             ],
         }
         mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
+        mock_client.get.return_value = mock_response
 
         OpenLibraryDataProvider.search("cats", facets={"mode": "everything"})
 
-        assert mock_get.call_args[1]["timeout"] == 30.0
-        assert mock_get.call_args[1]["timeout"] == _REQUEST_TIMEOUT
+        assert mock_client.get.call_args[1]["timeout"] == 30.0
+        assert mock_client.get.call_args[1]["timeout"] == _REQUEST_TIMEOUT
 
 
 class TestSearchTotalsByMode:
@@ -1224,32 +1286,62 @@ class TestSearchTotalsByMode:
             },
         ]
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_mode_buyable_total_is_filtered_len(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_mode_buyable_total_is_filtered_len(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
         mock_response = MagicMock()
         mock_response.json.return_value = {"numFound": 99, "docs": self._mock_docs_with_buyable_and_non_buyable()}
         mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
+        mock_client.get.return_value = mock_response
 
         result = OpenLibraryDataProvider.search("cats", facets={"mode": "buyable"})
         assert result.total == 1
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_mode_ebooks_total_uses_openlibrary_numfound(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_mode_ebooks_total_uses_openlibrary_numfound(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
         mock_response = MagicMock()
         mock_response.json.return_value = {"numFound": 77, "docs": self._mock_docs_with_buyable_and_non_buyable()}
         mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
+        mock_client.get.return_value = mock_response
 
         result = OpenLibraryDataProvider.search("cats", facets={"mode": "ebooks"})
         assert result.total == 77
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_mode_everything_total_uses_openlibrary_numfound(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_mode_everything_total_uses_openlibrary_numfound(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
         mock_response = MagicMock()
         mock_response.json.return_value = {"numFound": 66, "docs": self._mock_docs_with_buyable_and_non_buyable()}
         mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
+        mock_client.get.return_value = mock_response
 
         result = OpenLibraryDataProvider.search("cats", facets={"mode": "everything"})
         assert result.total == 66
+
+
+class TestHttpClientSingleton:
+    def test_same_client_returned(self):
+        import pyopds2_openlibrary
+        # Reset singleton for clean test
+        pyopds2_openlibrary._http_client = None
+        c1 = pyopds2_openlibrary._get_http_client()
+        c2 = pyopds2_openlibrary._get_http_client()
+        assert c1 is c2  # singleton
+        # Cleanup
+        pyopds2_openlibrary._http_client = None
+
+    def test_get_uses_client_not_httpx_get(self):
+        from unittest.mock import patch, MagicMock
+        import pyopds2_openlibrary
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_client.get.return_value = mock_response
+        with patch('pyopds2_openlibrary._get_http_client', return_value=mock_client):
+            pyopds2_openlibrary._get("https://openlibrary.org/search.json")
+            mock_client.get.assert_called_once()

--- a/tests/test_openlibrary_catalog.py
+++ b/tests/test_openlibrary_catalog.py
@@ -1,5 +1,6 @@
 """Tests for OpenLibrary OPDS Catalog creation."""
 
+import httpx
 import pytest
 from urllib.parse import parse_qs, urlparse
 from unittest.mock import patch, MagicMock
@@ -1117,8 +1118,8 @@ class TestRequestTimeoutUsage:
 
         fetch_languages_map()
 
-        assert mock_client.get.call_args[1]["timeout"] == 30.0
-        assert mock_client.get.call_args[1]["timeout"] == _REQUEST_TIMEOUT
+        expected = httpx.Timeout(connect=5.0, read=_REQUEST_TIMEOUT, write=5.0, pool=2.0)
+        assert mock_client.get.call_args[1]["timeout"] == expected
 
     @patch("pyopds2_openlibrary._get_http_client")
     def test_resolve_preferred_edition_editions_request_passes_timeout(self, mock_get_client):
@@ -1156,8 +1157,8 @@ class TestRequestTimeoutUsage:
 
         _resolve_preferred_edition("/works/OL40W", "eng", ["key", "title", "providers"])
 
-        assert mock_client.get.call_args_list[0].kwargs["timeout"] == 30.0
-        assert mock_client.get.call_args_list[0].kwargs["timeout"] == _REQUEST_TIMEOUT
+        expected = httpx.Timeout(connect=5.0, read=_REQUEST_TIMEOUT, write=5.0, pool=2.0)
+        assert mock_client.get.call_args_list[0].kwargs["timeout"] == expected
 
     @patch("pyopds2_openlibrary._get_http_client")
     def test_resolve_preferred_edition_search_request_passes_timeout(self, mock_get_client):
@@ -1195,8 +1196,8 @@ class TestRequestTimeoutUsage:
 
         _resolve_preferred_edition("/works/OL41W", "eng", ["key", "title", "providers"])
 
-        assert mock_client.get.call_args_list[1].kwargs["timeout"] == 30.0
-        assert mock_client.get.call_args_list[1].kwargs["timeout"] == _REQUEST_TIMEOUT
+        expected = httpx.Timeout(connect=5.0, read=_REQUEST_TIMEOUT, write=5.0, pool=2.0)
+        assert mock_client.get.call_args_list[1].kwargs["timeout"] == expected
 
     @patch("pyopds2_openlibrary._get_http_client")
     def test_count_for_mode_passes_timeout(self, mock_get_client):
@@ -1209,8 +1210,8 @@ class TestRequestTimeoutUsage:
 
         OpenLibraryDataProvider._count_for_mode("cats", "everything")
 
-        assert mock_client.get.call_args[1]["timeout"] == 30.0
-        assert mock_client.get.call_args[1]["timeout"] == _REQUEST_TIMEOUT
+        expected = httpx.Timeout(connect=5.0, read=_REQUEST_TIMEOUT, write=5.0, pool=2.0)
+        assert mock_client.get.call_args[1]["timeout"] == expected
 
     @patch("pyopds2_openlibrary._get_http_client")
     def test_search_passes_timeout(self, mock_get_client):
@@ -1242,8 +1243,8 @@ class TestRequestTimeoutUsage:
 
         OpenLibraryDataProvider.search("cats", facets={"mode": "everything"})
 
-        assert mock_client.get.call_args[1]["timeout"] == 30.0
-        assert mock_client.get.call_args[1]["timeout"] == _REQUEST_TIMEOUT
+        expected = httpx.Timeout(connect=5.0, read=_REQUEST_TIMEOUT, write=5.0, pool=2.0)
+        assert mock_client.get.call_args[1]["timeout"] == expected
 
 
 class TestSearchTotalsByMode:

--- a/tests/test_openlibrary_comprehensive.py
+++ b/tests/test_openlibrary_comprehensive.py
@@ -624,30 +624,36 @@ class TestGetRetryLogic:
     def _response(status_code: int, headers: dict[str, str] | None = None) -> httpx.Response:
         return httpx.Response(status_code=status_code, headers=headers or {}, request=httpx.Request("GET", "https://example.org"))
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_returns_response_on_first_successful_request(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_returns_response_on_first_successful_request(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         response = self._response(200)
-        mock_get.return_value = response
+        mock_get.get.return_value = response
 
         result = openlibrary._get("https://example.org")
 
         assert result is response
-        mock_get.assert_called_once()
+        mock_get.get.assert_called_once()
 
     @pytest.mark.parametrize("status_code", [500, 502, 503, 504])
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_retries_transient_http_errors_and_eventually_succeeds(self, mock_get, status_code: int):
-        mock_get.side_effect = [self._response(status_code), self._response(200)]
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_retries_transient_http_errors_and_eventually_succeeds(self, mock_get_client, status_code: int):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
+        mock_get.get.side_effect = [self._response(status_code), self._response(200)]
 
         result = openlibrary._get("https://example.org")
 
         assert result.status_code == 200
-        assert mock_get.call_count == 2
+        assert mock_get.get.call_count == 2
 
     @patch("pyopds2_openlibrary._time.sleep")
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_retry_after_is_capped(self, mock_get, mock_sleep):
-        mock_get.side_effect = [
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_retry_after_is_capped(self, mock_get_client, mock_sleep):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
+        mock_get.get.side_effect = [
             self._response(429, {"Retry-After": "1000"}),
             self._response(200),
         ]
@@ -657,66 +663,80 @@ class TestGetRetryLogic:
         assert result.status_code == 200
         mock_sleep.assert_any_call(10.0)
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_persistent_5xx_raises_after_retries_exhausted(self, mock_get):
-        mock_get.side_effect = [self._response(500), self._response(502), self._response(503)]
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_persistent_5xx_raises_after_retries_exhausted(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
+        mock_get.get.side_effect = [self._response(500), self._response(502), self._response(503)]
 
         with pytest.raises(httpx.HTTPStatusError):
             openlibrary._get("https://example.org")
 
-        assert mock_get.call_count == 3
+        assert mock_get.get.call_count == 3
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_404_raises_without_retry(self, mock_get):
-        mock_get.return_value = self._response(404)
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_404_raises_without_retry(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
+        mock_get.get.return_value = self._response(404)
 
         with pytest.raises(httpx.HTTPStatusError):
             openlibrary._get("https://example.org")
 
-        mock_get.assert_called_once()
+        mock_get.get.assert_called_once()
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_transport_error_retries_then_raises(self, mock_get):
-        mock_get.side_effect = [httpx.TransportError("boom"), httpx.TransportError("boom"), httpx.TransportError("boom")]
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_transport_error_retries_then_raises(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
+        mock_get.get.side_effect = [httpx.TransportError("boom"), httpx.TransportError("boom"), httpx.TransportError("boom")]
 
         with pytest.raises(httpx.TransportError):
             openlibrary._get("https://example.org")
 
-        assert mock_get.call_count == 3
+        assert mock_get.get.call_count == 3
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_transport_error_still_retries_until_last_attempt(self, mock_get):
-        mock_get.side_effect = [httpx.TransportError("boom"), httpx.TransportError("boom"), self._response(200)]
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_transport_error_still_retries_until_last_attempt(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
+        mock_get.get.side_effect = [httpx.TransportError("boom"), httpx.TransportError("boom"), self._response(200)]
 
         result = openlibrary._get("https://example.org")
 
         assert result.status_code == 200
-        assert mock_get.call_count == 3
+        assert mock_get.get.call_count == 3
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_known_marc_code_to_iso_code(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_known_marc_code_to_iso_code(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         _reset_languages_map_cache()
         resp = MagicMock()
         resp.raise_for_status.return_value = None
         resp.json.return_value = [
             {"key": "/languages/eng", "identifiers": {"iso_639_1": ["en"]}},
         ]
-        mock_get.return_value = resp
+        mock_get.get.return_value = resp
         assert marc_language_to_iso_639_1("eng") == "en"
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_unknown_marc_code_returns_none(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_unknown_marc_code_returns_none(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         _reset_languages_map_cache()
         resp = MagicMock()
         resp.raise_for_status.return_value = None
         resp.json.return_value = [
             {"key": "/languages/eng", "identifiers": {"iso_639_1": ["en"]}},
         ]
-        mock_get.return_value = resp
+        mock_get.get.return_value = resp
         assert marc_language_to_iso_639_1("fra") is None
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_iso_639_1_to_marc_reverse_lookup(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_iso_639_1_to_marc_reverse_lookup(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         _reset_languages_map_cache()
         openlibrary._iso_to_marc_cache.clear()
         resp = MagicMock()
@@ -725,14 +745,16 @@ class TestGetRetryLogic:
             {"key": "/languages/eng", "identifiers": {"iso_639_1": ["en"]}},
             {"key": "/languages/fre", "identifiers": {"iso_639_1": ["fr"]}},
         ]
-        mock_get.return_value = resp
+        mock_get.get.return_value = resp
         assert iso_639_1_to_marc("en") == "eng"
         assert iso_639_1_to_marc("fr") == "fre"
         assert iso_639_1_to_marc("eng") == "eng"
         assert iso_639_1_to_marc("zz") is None
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_languages_without_iso_639_1_skipped(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_languages_without_iso_639_1_skipped(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         _reset_languages_map_cache()
         resp = MagicMock()
         resp.raise_for_status.return_value = None
@@ -741,36 +763,40 @@ class TestGetRetryLogic:
             {"key": "/languages/fra", "identifiers": {}},
             {"key": "/languages/deu", "identifiers": None},
         ]
-        mock_get.return_value = resp
+        mock_get.get.return_value = resp
         mapping = fetch_languages_map()
         assert mapping == {"eng": "en"}
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_fetch_languages_map_cache_prevents_second_http_call(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_fetch_languages_map_cache_prevents_second_http_call(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         _reset_languages_map_cache()
         resp = MagicMock()
         resp.raise_for_status.return_value = None
         resp.json.return_value = [{"key": "/languages/eng", "identifiers": {"iso_639_1": ["en"]}}]
-        mock_get.return_value = resp
+        mock_get.get.return_value = resp
         first = fetch_languages_map()
         second = fetch_languages_map()
         assert first == second == {"eng": "en"}
-        assert mock_get.call_count == 1
+        assert mock_get.get.call_count == 1
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_fetch_languages_map_failure_returns_previous_cache(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_fetch_languages_map_failure_returns_previous_cache(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         _reset_languages_map_cache()
         cached = {"eng": "en"}
         openlibrary._languages_map_cache = cached
         openlibrary._languages_map_fetched_at = 0.0
 
-        mock_get.side_effect = httpx.TransportError("boom")
+        mock_get.get.side_effect = httpx.TransportError("boom")
 
         with patch("pyopds2_openlibrary._time.monotonic", return_value=openlibrary._LANGUAGES_MAP_TTL + 1):
             mapping = fetch_languages_map()
 
         assert mapping is cached
-        assert mock_get.call_count == 3
+        assert mock_get.get.call_count == 3
 
 
 class TestPriceParsing:
@@ -859,8 +885,10 @@ class TestFilterHelpers:
 
 class TestResolvePreferredEdition:
     @patch("pyopds2_openlibrary.fetch_languages_map", return_value={"eng": "en", "fre": "fr"})
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_returns_matching_edition(self, mock_get, _):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_returns_matching_edition(self, mock_get_client, _):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         single = MagicMock()
         single.raise_for_status.return_value = None
         single.json.return_value = {
@@ -881,14 +909,16 @@ class TestResolvePreferredEdition:
                 }
             ]
         }
-        mock_get.return_value = single
+        mock_get.get.return_value = single
         resolved = _resolve_preferred_edition("/works/OL1W", "eng", ["key", "title", "providers"])
         assert resolved is not None
         assert resolved.edition.key == "/books/OL999M"
 
     @patch("pyopds2_openlibrary.fetch_languages_map", return_value={"eng": "en", "fre": "fr"})
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_returns_none_when_no_language_match(self, mock_get, _):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_returns_none_when_no_language_match(self, mock_get_client, _):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         first = MagicMock()
         first.raise_for_status.return_value = None
         first.json.return_value = {"docs": []}
@@ -899,16 +929,21 @@ class TestResolvePreferredEdition:
                 {"key": "/books/OL999M", "languages": [{"key": "/languages/fra"}]},
             ]
         }
-        mock_get.side_effect = [first, second]
+        mock_get.get.side_effect = [first, second]
         assert _resolve_preferred_edition("/works/OL1W", "eng", ["key"]) is None
 
-    @patch("pyopds2_openlibrary.httpx.get", side_effect=Exception("boom"))
-    def test_returns_none_on_http_failure(self, _):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_returns_none_on_http_failure(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
+        mock_get.get.side_effect = Exception("boom")
         assert _resolve_preferred_edition("/works/OL1W", "eng", ["key"]) is None
 
     @patch("pyopds2_openlibrary.fetch_languages_map", return_value={"eng": "en", "fre": "fr"})
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_author_data_populated_from_preferred_edition_search(self, mock_get, _):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_author_data_populated_from_preferred_edition_search(self, mock_get_client, _):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         single = MagicMock()
         single.raise_for_status.return_value = None
         single.json.return_value = {
@@ -920,14 +955,16 @@ class TestResolvePreferredEdition:
                 }
             ]
         }
-        mock_get.return_value = single
+        mock_get.get.return_value = single
         resolved = _resolve_preferred_edition("/works/OL1W", "eng", ["key", "title", "providers"])
         assert resolved.author_name == ["Localized Name"]
         assert resolved.author_key == ["OLLOCAL"]
 
     @patch("pyopds2_openlibrary.fetch_languages_map", return_value={"eng": "en", "fre": "fr"})
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_falls_back_to_two_call_strategy_when_single_call_mismatches(self, mock_get, _):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_falls_back_to_two_call_strategy_when_single_call_mismatches(self, mock_get_client, _):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         first = MagicMock()
         first.raise_for_status.return_value = None
         first.json.return_value = {
@@ -969,7 +1006,7 @@ class TestResolvePreferredEdition:
                 }
             ]
         }
-        mock_get.side_effect = [first, second, third]
+        mock_get.get.side_effect = [first, second, third]
         resolved = _resolve_preferred_edition("/works/OL1W", "eng", ["key", "title", "providers"])
         assert resolved is not None
         assert resolved.edition.key == "/books/OLENG"
@@ -1250,8 +1287,10 @@ class TestHomeFeed:
 
 
 class TestFacetCounts:
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_count_fetch_returns_all_modes(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_count_fetch_returns_all_modes(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         def _side_effect(*args, **kwargs):
             response = MagicMock()
             response.raise_for_status.return_value = None
@@ -1264,7 +1303,7 @@ class TestFacetCounts:
                 response.json.return_value = {"numFound": 33}
             return response
 
-        mock_get.side_effect = _side_effect
+        mock_get.get.side_effect = _side_effect
         counts = fetch_facet_counts("cats")
         assert set(counts.keys()) == {"everything", "ebooks", "print_disabled", "open_access", "buyable"}
 
@@ -1279,24 +1318,28 @@ class TestFacetCounts:
         called_modes = [call.args[1] for call in mock_count.call_args_list]
         assert "ebooks" not in called_modes
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_ebooks_mode_appends_ebook_access_filter(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_ebooks_mode_appends_ebook_access_filter(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         resp = MagicMock()
         resp.raise_for_status.return_value = None
         resp.json.return_value = {"numFound": 5}
-        mock_get.return_value = resp
+        mock_get.get.return_value = resp
         OpenLibraryDataProvider._count_for_mode("cats", "ebooks")
-        q = mock_get.call_args.kwargs["params"]["q"]
+        q = mock_get.get.call_args.kwargs["params"]["q"]
         assert "printdisabled" in q
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_open_access_mode_appends_public_filter(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_open_access_mode_appends_public_filter(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         resp = MagicMock()
         resp.raise_for_status.return_value = None
         resp.json.return_value = {"numFound": 5}
-        mock_get.return_value = resp
+        mock_get.get.return_value = resp
         OpenLibraryDataProvider._count_for_mode("cats", "open_access")
-        q = mock_get.call_args.kwargs["params"]["q"]
+        q = mock_get.get.call_args.kwargs["params"]["q"]
         assert "public" in q
 
 
@@ -1334,83 +1377,99 @@ class TestSearch:
             "editions": editions,
         }
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_basic_search_returns_search_response(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_basic_search_returns_search_response(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         response = MagicMock()
         response.raise_for_status.return_value = None
         response.json.return_value = {
             "numFound": 1,
             "docs": [self._search_doc("/works/OL1W", "Book", "9.99 USD", "borrow_available")],
         }
-        mock_get.return_value = response
+        mock_get.get.return_value = response
         result = OpenLibraryDataProvider.search("cats", facets={"mode": "everything"})
         assert isinstance(result, DataProvider.SearchResponse)
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_mode_everything_strips_existing_ebook_access_filter(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_mode_everything_strips_existing_ebook_access_filter(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         response = MagicMock()
         response.raise_for_status.return_value = None
         response.json.return_value = {"numFound": 0, "docs": []}
-        mock_get.return_value = response
+        mock_get.get.return_value = response
         OpenLibraryDataProvider.search("cats ebook_access:public", facets={"mode": "everything"})
-        q = mock_get.call_args.kwargs["params"]["q"]
+        q = mock_get.get.call_args.kwargs["params"]["q"]
         assert "cats" in q
         assert "ebook_access" in q
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_mode_ebooks_appends_filter(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_mode_ebooks_appends_filter(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         response = MagicMock()
         response.raise_for_status.return_value = None
         response.json.return_value = {"numFound": 0, "docs": []}
-        mock_get.return_value = response
+        mock_get.get.return_value = response
         OpenLibraryDataProvider.search("cats", facets={"mode": "ebooks"})
-        q = mock_get.call_args.kwargs["params"]["q"]
+        q = mock_get.get.call_args.kwargs["params"]["q"]
         assert "printdisabled" in q
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_mode_open_access_appends_filter(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_mode_open_access_appends_filter(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         response = MagicMock()
         response.raise_for_status.return_value = None
         response.json.return_value = {"numFound": 0, "docs": []}
-        mock_get.return_value = response
+        mock_get.get.return_value = response
         OpenLibraryDataProvider.search("cats", facets={"mode": "open_access"})
-        q = mock_get.call_args.kwargs["params"]["q"]
+        q = mock_get.get.call_args.kwargs["params"]["q"]
         assert "public" in q
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_mode_print_disabled_appends_filter(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_mode_print_disabled_appends_filter(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         response = MagicMock()
         response.raise_for_status.return_value = None
         response.json.return_value = {"numFound": 0, "docs": []}
-        mock_get.return_value = response
+        mock_get.get.return_value = response
         OpenLibraryDataProvider.search("cats", facets={"mode": "print_disabled"})
-        q = mock_get.call_args.kwargs["params"]["q"]
+        q = mock_get.get.call_args.kwargs["params"]["q"]
         assert "printdisabled" in q
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_media_type_audiobook_adds_subject_filter(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_media_type_audiobook_adds_subject_filter(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         response = MagicMock()
         response.raise_for_status.return_value = None
         response.json.return_value = {"numFound": 0, "docs": []}
-        mock_get.return_value = response
+        mock_get.get.return_value = response
         OpenLibraryDataProvider.search("cats", media_type="audiobook")
-        q = mock_get.call_args.kwargs["params"]["q"]
+        q = mock_get.get.call_args.kwargs["params"]["q"]
         assert "id_librivox:*" in q
         assert "ebook_access" in q
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_media_type_ebook_adds_filter_when_missing(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_media_type_ebook_adds_filter_when_missing(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         response = MagicMock()
         response.raise_for_status.return_value = None
         response.json.return_value = {"numFound": 0, "docs": []}
-        mock_get.return_value = response
+        mock_get.get.return_value = response
         OpenLibraryDataProvider.search("cats", media_type="ebook")
-        q = mock_get.call_args.kwargs["params"]["q"]
+        q = mock_get.get.call_args.kwargs["params"]["q"]
         assert "ebook_access" in q
         assert "printdisabled" in q
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_media_type_ebook_filters_out_librivox_records(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_media_type_ebook_filters_out_librivox_records(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         response = MagicMock()
         response.raise_for_status.return_value = None
         response.json.return_value = {
@@ -1441,12 +1500,14 @@ class TestSearch:
                 },
             ],
         }
-        mock_get.return_value = response
+        mock_get.get.return_value = response
         result = OpenLibraryDataProvider.search("cats", media_type="ebook")
         assert [r.title for r in result.records] == ["Ebook"]
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_mode_buyable_filters_to_non_free_providers(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_mode_buyable_filters_to_non_free_providers(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         response = MagicMock()
         response.raise_for_status.return_value = None
         response.json.return_value = {
@@ -1456,12 +1517,14 @@ class TestSearch:
                 self._search_doc("/works/OL2W", "Free", "0.00 USD", "borrow_available"),
             ],
         }
-        mock_get.return_value = response
+        mock_get.get.return_value = response
         result = OpenLibraryDataProvider.search("cats", facets={"mode": "buyable"})
         assert [r.title for r in result.records] == ["Paid"]
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_mode_buyable_total_equals_filtered_len(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_mode_buyable_total_equals_filtered_len(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         response = MagicMock()
         response.raise_for_status.return_value = None
         response.json.return_value = {
@@ -1471,23 +1534,27 @@ class TestSearch:
                 self._search_doc("/works/OL2W", "Free", "0.00 USD", "borrow_available"),
             ],
         }
-        mock_get.return_value = response
+        mock_get.get.return_value = response
         result = OpenLibraryDataProvider.search("cats", facets={"mode": "buyable"})
         assert result.total == len(result.records) == 1
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_mode_everything_no_ebook_filter(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_mode_everything_no_ebook_filter(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         response = MagicMock()
         response.raise_for_status.return_value = None
         response.json.return_value = {"numFound": 0, "docs": []}
-        mock_get.return_value = response
+        mock_get.get.return_value = response
         OpenLibraryDataProvider.search("cats", facets={"mode": "everything"})
-        q = mock_get.call_args.kwargs["params"]["q"]
+        q = mock_get.get.call_args.kwargs["params"]["q"]
         assert "cats" in q
         assert "ebook_access" in q
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_records_without_acquisition_options_are_filtered(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_records_without_acquisition_options_are_filtered(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         response = MagicMock()
         response.raise_for_status.return_value = None
         response.json.return_value = {
@@ -1509,13 +1576,15 @@ class TestSearch:
                 ),
             ],
         }
-        mock_get.return_value = response
+        mock_get.get.return_value = response
         result = OpenLibraryDataProvider.search("cats", facets={"mode": "everything"})
         assert [r.title for r in result.records] == ["Has provider"]
 
     @pytest.mark.parametrize("mode", ["ebooks", "buyable"])
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_available_books_sorted_before_unavailable(self, mock_get, mode: str):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_available_books_sorted_before_unavailable(self, mock_get_client, mode: str):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         # Use "public" ebook_access for ebooks/buyable modes (these are about filtering availability, not print-disabled)
         response = MagicMock()
         response.raise_for_status.return_value = None
@@ -1526,13 +1595,15 @@ class TestSearch:
                 self._search_doc("/works/OL2W", "Available", "9.99 USD", "borrow_available", ebook_access="borrowable"),
             ],
         }
-        mock_get.return_value = response
+        mock_get.get.return_value = response
         result = OpenLibraryDataProvider.search("cats", facets={"mode": mode})
         assert [r.title for r in result.records][:2] == ["Available", "Unavailable"]
 
     @patch("pyopds2_openlibrary.fetch_languages_map", return_value={"eng": "en", "fre": "fr"})
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_language_matched_editions_moved_first(self, mock_get, _):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_language_matched_editions_moved_first(self, mock_get_client, _):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         response = MagicMock()
         response.raise_for_status.return_value = None
         response.json.return_value = {
@@ -1562,14 +1633,16 @@ class TestSearch:
                 )
             ],
         }
-        mock_get.return_value = response
+        mock_get.get.return_value = response
         result = OpenLibraryDataProvider.search("cats", language="eng")
         assert result.records[0].editions.docs[0].key == "/books/OLENG"
 
     @patch("pyopds2_openlibrary.fetch_languages_map", return_value={"eng": "en", "fre": "fr"})
     @patch("pyopds2_openlibrary._resolve_preferred_edition")
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_edition_key_query_substitutes_foreign_language_edition(self, mock_get, mock_resolve, _):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_edition_key_query_substitutes_foreign_language_edition(self, mock_get_client, mock_resolve, _):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         response = MagicMock()
         response.raise_for_status.return_value = None
         response.json.return_value = {
@@ -1592,7 +1665,7 @@ class TestSearch:
                 )
             ],
         }
-        mock_get.return_value = response
+        mock_get.get.return_value = response
         mock_resolve.return_value = SimpleNamespace(
             edition=OpenLibraryDataRecord.EditionDoc.model_validate(
                 {
@@ -1611,8 +1684,10 @@ class TestSearch:
         assert result.records[0].editions.docs[0].key == "/books/OLENG"
         assert result.records[0].author_name == ["Localized Author"]
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_require_cover_false_keeps_results_without_cover(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_require_cover_false_keeps_results_without_cover(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         no_cover_doc = self._search_doc(
             "/works/OLNOCOVER",
             "No Cover",
@@ -1634,42 +1709,48 @@ class TestSearch:
             "numFound": 1,
             "docs": [no_cover_doc],
         }
-        mock_get.return_value = response
+        mock_get.get.return_value = response
         result = OpenLibraryDataProvider.search("cats", require_cover=False)
         assert len(result.records) == 1
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_title_parameter_propagates_to_response_title(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_title_parameter_propagates_to_response_title(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         response = MagicMock()
         response.raise_for_status.return_value = None
         response.json.return_value = {
             "numFound": 1,
             "docs": [self._search_doc("/works/OL1W", "Book", "9.99 USD", "borrow_available")],
         }
-        mock_get.return_value = response
+        mock_get.get.return_value = response
         result = OpenLibraryDataProvider.search("cats", title="Curated")
         assert result.title == "Curated"
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_title_injected_into_pagination_params(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_title_injected_into_pagination_params(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         response = MagicMock()
         response.raise_for_status.return_value = None
         response.json.return_value = {
             "numFound": 1,
             "docs": [self._search_doc("/works/OL1W", "Book", "9.99 USD", "borrow_available")],
         }
-        mock_get.return_value = response
+        mock_get.get.return_value = response
         result = OpenLibraryDataProvider.search("cats", limit=10, offset=20, title="Curated")
         assert result.params["title"] == "Curated"
 
-    @patch("pyopds2_openlibrary.httpx.get")
-    def test_no_title_leaves_params_unchanged(self, mock_get):
+    @patch("pyopds2_openlibrary._get_http_client")
+    def test_no_title_leaves_params_unchanged(self, mock_get_client):
+        mock_get = MagicMock()
+        mock_get_client.return_value = mock_get
         response = MagicMock()
         response.raise_for_status.return_value = None
         response.json.return_value = {
             "numFound": 1,
             "docs": [self._search_doc("/works/OL1W", "Book", "9.99 USD", "borrow_available")],
         }
-        mock_get.return_value = response
+        mock_get.get.return_value = response
         result = OpenLibraryDataProvider.search("cats", limit=10, offset=20)
         assert "title" not in result.params


### PR DESCRIPTION
## Summary

Replaces per-call \`httpx.get()\` with a shared \`httpx.Client\` singleton to eliminate per-request TLS handshake overhead when reader.archive.org fans out carousel fetches to Open Library.

**Problem**: every call to \`_get()\` was creating a new TCP+TLS connection — a cold connection costs ~200 ms of latency. With N carousel slots fetching in parallel, this caused TLS burst storms against OL.

**Fix**: a module-level \`httpx.Client\` is created once (thread-safe double-checked locking, lazy init) and reused for all subsequent requests. Connection pool settings:
- \`max_keepalive_connections=10\`
- \`max_connections=20\`
- \`keepalive_expiry=30.0 s\`

The public API (\`_get\`) is unchanged — callers see no difference.

## Changes

- \`pyopds2_openlibrary/__init__.py\`: add \`_get_http_client()\` singleton; update \`_get()\` to call \`client.get()\` instead of \`httpx.get()\`
- \`tests/\`: update all mocks from \`httpx.get\` → \`_get_http_client\` (282 tests pass)

## Testing

**Unit tests:**
```
282 passed in 24.49s
```

**E2E with opds.openlibrary.org service + Cloudflare tunnel + reader.archive.org:**

Started the OPDS service locally with this library via \`PYTHONPATH\` override and \`CACHE_ENABLED=false\` so every request hit real OL:

```
PYTHONPATH=~/Projects/pyopds2_openlibrary-httpx-pool \
CACHE_ENABLED=false OL_BASE_URL=https://openlibrary.org \
uvicorn app.main:app --host 127.0.0.1 --port 8090
```

Local smoke tests:
```
/health → 200
/ → 3 groups with publications
/?page=2 → 200 with groups
/search?query=tolkien → 443 results
  availability facet: numberOfItems=None ✓ (regression guard)
```

Cloudflare tunnel (`cloudflared tunnel --url http://127.0.0.1:8090`) verified reachable externally. reader.archive.org connected to feed and rendered carousels correctly.

See [docs/testing-opds-locally.md](https://github.com/ArchiveLabs/opds.openlibrary.org/blob/main/docs/testing-opds-locally.md) (ArchiveLabs/opds.openlibrary.org PR #43) for the reusable testing process documented from this session.

Closes #99