### PR TITLE
fix(search): skip active-mode count query — use numFound instead

### DIFF
--- a/pyopds2_openlibrary/__init__.py
+++ b/pyopds2_openlibrary/__init__.py
@@ -1322,8 +1322,12 @@ class OpenLibraryDataProvider(DataProvider):
     ) -> dict[str, Optional[int]]:
         """Fetch ``numberOfItems`` counts for every availability mode.
 
-        If *known_mode* and *known_total* are provided the count request for
-        that mode is skipped (we already have it from the main search).
+        If *known_mode* is provided the count request for that mode is skipped
+        entirely — the caller already has it from the main search ``numFound``
+        and will overwrite the placeholder after this call returns.  Supply
+        *known_total* as well when you want the dict value pre-filled (e.g.
+        when running sequentially); omit it when running in parallel with the
+        main search and you'll overwrite it yourself afterward.
 
         Modes that cannot be counted server-side (e.g. ``buyable``) will have
         a ``None`` value unless supplied via *known_mode*/*known_total*.
@@ -1339,7 +1343,8 @@ class OpenLibraryDataProvider(DataProvider):
         counts: dict[str, Optional[int]] = {}
         to_fetch: list[str] = []
         for m in modes:
-            if known_mode and m == known_mode and known_total is not None:
+            if known_mode and m == known_mode:
+                # Skip the Solr round-trip; caller will overwrite with numFound.
                 counts[m] = known_total
             elif m == "buyable":
                 counts[m] = None


### PR DESCRIPTION
## Problem

Every OPDS search fires **5 requests to OL** instead of 4:
1. Main `GET /search.json` (returns results + numFound)
2–5. Four `limit=0` `GET /search.json` calls to get `numberOfItems` for the availability-mode facet links (everything, ebooks, print_disabled, open_access)

The active mode's count query (#2–5) is always **immediately overwritten** by `numFound` from the main search:
```python
availability_counts[mode] = safe_total  # overwrites the limit=0 result
```
So 1 of the 4 count queries is always wasted.

## Root cause

`fetch_facet_counts` skips the active mode's count query only when **both** `known_mode` and `known_total` are supplied:
```python
if known_mode and m == known_mode and known_total is not None:
    counts[m] = known_total  # skip Solr round-trip
```

The caller in `opds.openlibrary.org` runs the main search and facet counts in **parallel** via `asyncio.gather`, so `known_total` is unavailable at the time of the call — causing all 4 count queries to fire.

## Fix

Remove the `known_total is not None` guard. Passing `known_mode` alone now skips the Solr query and stores `known_total` (possibly `None`) as a placeholder. The caller overwrites `availability_counts[mode]` with the real `numFound` after `asyncio.gather` completes — exactly as before.

Net effect: **3 count queries instead of 4** when the caller supplies `known_mode`.

## Companion PR

`opds.openlibrary.org` PR (wires up `known_mode` in `_fetch_facet_counts_safe`): ArchiveLabs/opds.openlibrary.org#40

That PR must deploy alongside this one for the reduction to take effect.

## Testing

- 280 tests pass (unchanged count)
- Backward compatible: existing callers that pass neither `known_mode` nor `known_total` are unaffected (all 4 modes still fetched as before)