### PR TITLE
perf(_get): tighten retry backoff to a ~1s total budget

### DIFF
--- a/pyopds2_openlibrary/__init__.py
+++ b/pyopds2_openlibrary/__init__.py
@@ -77,11 +77,14 @@ _REQUEST_TIMEOUT: float = 30.0
 
 # HTTP status codes that indicate a transient server-side failure worth retrying.
 _RETRY_STATUS_CODES: frozenset[int] = frozenset({429, 500, 502, 503, 504})
-# Default delays between attempts (seconds): 3 total attempts — immediate, +1 s, +2 s.
-# A 429 Retry-After header overrides the per-attempt delay when present.
-_RETRY_DELAYS: tuple[float, ...] = (0.0, 1.0, 2.0)
-# Cap on Retry-After to avoid holding a thread-pool thread for too long.
-_RETRY_AFTER_MAX: float = 10.0
+# Default delays between attempts (seconds): 3 total attempts — immediate, +0.25 s,
+# +0.5 s. These requests are on the critical path of user-facing pages, so the
+# total backoff budget is kept under ~1 s — a transient blip should cost a beat,
+# not seconds. A 429 Retry-After header overrides the per-attempt delay when
+# present (capped below to stay within the same budget).
+_RETRY_DELAYS: tuple[float, ...] = (0.0, 0.25, 0.5)
+# Cap on Retry-After so a server asking us to wait can't blow the ~1 s budget.
+_RETRY_AFTER_MAX: float = 0.5
 # Default User-Agent. OpenLibrary's edge blocks the default httpx UA with 403,
 # so every outbound request must identify itself. Consumers should override
 # via ``OpenLibraryDataProvider.USER_AGENT`` to include contact info.

--- a/tests/test_openlibrary_comprehensive.py
+++ b/tests/test_openlibrary_comprehensive.py
@@ -655,7 +655,8 @@ class TestGetRetryLogic:
         result = openlibrary._get("https://example.org")
 
         assert result.status_code == 200
-        mock_sleep.assert_any_call(10.0)
+        # A large Retry-After must be clamped to the cap, not honored literally.
+        mock_sleep.assert_any_call(openlibrary._RETRY_AFTER_MAX)
 
     @patch("pyopds2_openlibrary.httpx.get")
     def test_persistent_5xx_raises_after_retries_exhausted(self, mock_get):


### PR DESCRIPTION
These requests sit on the critical path of user-facing search/home pages, but the retry backoff was tuned for a background job: delays of (0, 1.0, 2.0)s meant a single transient 429/5xx added a full 1.0s of time.sleep, and a persistent failure burned 3.0s before giving up. A 429 Retry-After was honored up to 10s.

Shorten to delays (0, 0.25, 0.5)s and cap Retry-After at 0.5s, keeping the total backoff budget under ~1s — a transient blip should cost a beat, not seconds.

Measured (mocked transient responses):
- one 503 then 200 : 1.001s -> 0.251s
- two 503 then 200 : 3.001s -> 0.752s
- persistent 5xx (give up): 3.002s -> 0.751s
- 429 Retry-After: 30  : honored ~10s -> clamped to 0.502s

test_retry_after_is_capped now asserts against _RETRY_AFTER_MAX instead of a hardcoded value so it won't drift. All 280 library tests pass.