### PR TITLE
fix: hide entries whose only LibriVox link is a catalog page

### DIFF
--- a/pyopds2_openlibrary/__init__.py
+++ b/pyopds2_openlibrary/__init__.py
@@ -758,11 +758,13 @@ def _has_acquisition_options(record: OpenLibraryDataRecord) -> bool:
 
     Mirrors the filtering logic in ``ol_acquisition_to_opds_links`` so that
     books with no actionable link are hidden from results.
+
+    A work-level ``id_librivox`` is deliberately *not* enough on its own: the
+    LibriVox fallback in ``links()`` is a plain ``rel=alternate`` catalog page,
+    which no OPDS client can acquire or open.  Such an entry must come from the
+    edition's own providers (IA webpub, epub/pdf download, or a purchase link)
+    to be servable.
     """
-    # Works with a LibriVox recording always have audio content, even when the
-    # edition returned by OL's search API is a print/ebook edition with no providers.
-    if record.id_librivox:
-        return True
     edition = record.editions.docs[0] if record.editions and record.editions.docs else None
     if not edition or not edition.providers:
         return False

--- a/tests/test_openlibrary_catalog.py
+++ b/tests/test_openlibrary_catalog.py
@@ -575,6 +575,52 @@ class TestHasAcquisitionOptions:
         record = OpenLibraryDataRecord(key="/works/OL12W", title="No editions")
         assert _has_acquisition_options(record) is False
 
+    def test_returns_false_for_librivox_only_audio_provider(self):
+        """OL58393454M: the only provider is a LibriVox ``audio`` entry, which
+        yields no acquisition link — just a ``rel=alternate`` catalog page."""
+        record = _record_with_providers(
+            OpenLibraryDataRecord.EditionProvider(
+                provider_name="librivox",
+                format="audio",
+                access="open-access",
+                url="https://librivox.org/21236",
+            ),
+        )
+        record.id_librivox = ["21236"]
+        assert _has_acquisition_options(record) is False
+
+    def test_returns_false_for_librivox_work_whose_edition_has_no_providers(self):
+        record = OpenLibraryDataRecord(
+            key="/works/OL13W",
+            title="Print edition of a LibriVox work",
+            id_librivox=["12345"],
+            editions=OpenLibraryDataRecord.EditionsResultSet(
+                docs=[OpenLibraryDataRecord.EditionDoc(key="/books/OL13M", title="Edition")]
+            ),
+        )
+        assert _has_acquisition_options(record) is False
+
+    def test_returns_true_for_librivox_work_with_ia_provider(self):
+        """The common LibriVox case: the edition is on IA, so it still gets a
+        webpub link and must stay visible."""
+        edition = OpenLibraryDataRecord.EditionDoc(
+            key="/books/OL14M",
+            title="Edition",
+            ia=["aroomofonesown_1906_librivox"],
+            providers=[
+                OpenLibraryDataRecord.EditionProvider(
+                    provider_name="ia", format="audio", url="https://archive.org/details/x"
+                ),
+            ],
+        )
+        record = OpenLibraryDataRecord(
+            key="/works/OL14W",
+            title="Work",
+            id_librivox=["21236"],
+            editions=OpenLibraryDataRecord.EditionsResultSet(docs=[edition]),
+        )
+        assert _has_acquisition_options(record) is True
+
 
 class TestAcquisitionLinkRelFallback:
     def test_access_none_uses_generic_acquisition_rel(self):


### PR DESCRIPTION
_has_acquisition_options short-circuited to True for any record with a work-level id_librivox, on the assumption that such works always carry audio content.  But a LibriVox "audio" provider produces no link at all in ol_acquisition_to_opds_links, so when the edition has no IA provider the entry ships with only rel=alternate links -- nothing an OPDS client can acquire or open.

OL58393454M (A Room of One's Own) is one such entry: its sole provider is librivox/audio with no editions.ia, so /opds/books/OL58393454M served a publication with zero acquisition links.

Drop the short-circuit so servability is decided by the edition's own providers (IA webpub, epub/pdf download, or a web+buy purchase link). LibriVox works remain visible through their IA provider, which covers 98 of 100 id_librivox works sampled from live search.